### PR TITLE
Implement MP3 (chapter-split) output format and add per-book convert action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /audplexus ./cmd/server
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.23
 
 RUN apk add --no-cache ffmpeg ca-certificates tzdata su-exec
 

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/mstrhakr/audplexus/internal/logging"
 )
@@ -164,6 +165,16 @@ func (f *FFmpeg) buildDecryptArgs(inputPath, outputPath, activationBytes, key, i
 	}
 
 	args = append(args, "-c", "copy")
+	// +faststart relocates the MP4 moov atom (the index) to the front of
+	// the output file. Audible delivers AAX/AAXC with moov at the END,
+	// and stream-copy preserves that layout. Any downstream ffmpeg
+	// invocation that opens the m4b then has to scan the whole file
+	// trying to find the index — observed ffmpeg RSS climbing to 7+ GB
+	// when SplitChapters opened a 573 MB book. Faststart costs us one
+	// extra pass over the file during decrypt (still seconds on stream
+	// copy speeds) and makes everything afterwards constant-memory.
+	// Helps Plex/Emby metadata scans too.
+	args = append(args, "-movflags", "+faststart")
 	args = append(args, buildMetadataArgs(meta)...)
 	args = append(args, "-y", outputPath)
 	return args
@@ -358,7 +369,7 @@ func (f *FFmpeg) ConvertToMP3(inputPath, outputPath string, bitrate string) erro
 		bitrate = "128k"
 	}
 	decryptLog.Info().Str("input", inputPath).Str("output", outputPath).Str("bitrate", bitrate).Msg("converting to MP3")
-	return f.run(
+	return f.runTranscode(
 		"-i", inputPath,
 		"-codec:a", "libmp3lame",
 		"-b:a", bitrate,
@@ -401,7 +412,7 @@ func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) er
 	defer os.Remove(listPath)
 
 	decryptLog.Info().Int("inputs", len(inputPaths)).Str("output", outputPath).Msg("concatenating chapters into m4b")
-	return f.run(
+	return f.runTranscode(
 		"-f", "concat",
 		"-safe", "0",
 		"-i", listPath,
@@ -414,29 +425,67 @@ func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) er
 }
 
 // SplitChapters splits an audio file into separate chapter files.
-func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMark, format string) error {
+//
+// For "m4b" output the call is a stream copy (cheap). For "mp3" output
+// each chapter is re-encoded with libmp3lame.
+//
+// onChapter, when non-nil, is invoked after each chapter finishes encoding
+// with (1-based-index, total) so callers can report progress to the UI.
+func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMark, format string, onChapter func(done, total int)) error {
 	decryptLog.Info().Str("input", inputPath).Int("chapters", len(chapters)).Str("format", format).Msg("splitting chapters")
 	ext := ".m4b"
 	codec := []string{"-c", "copy"}
+	reencode := false
 	if format == "mp3" {
 		ext = ".mp3"
 		codec = []string{"-codec:a", "libmp3lame", "-b:a", "128k"}
+		reencode = true
 	}
 
 	for i, ch := range chapters {
 		outputPath := fmt.Sprintf("%s/%02d - %s%s", outputDir, i+1, sanitizeFilename(ch.Title), ext)
+		// -ss/-to MUST come before -i so ffmpeg uses input-side fast seek
+		// (jumps to the byte offset via the container index). Output-side
+		// seek decodes-and-discards from the start of the file, which on a
+		// 10-hour audiobook means buffering hours of audio in the muxer
+		// queue before emitting the first output byte.
 		args := []string{
-			"-i", inputPath,
 			"-ss", formatDuration(ch.StartMs),
 		}
 		if ch.EndMs > 0 {
 			args = append(args, "-to", formatDuration(ch.EndMs))
 		}
+		args = append(args, "-i", inputPath)
 		args = append(args, codec...)
 		args = append(args, "-y", outputPath)
 
-		if err := f.run(args...); err != nil {
+		chapterStart := time.Now()
+		decryptLog.Info().
+			Int("chapter", i+1).
+			Int("of", len(chapters)).
+			Str("title", ch.Title).
+			Int("start_ms", ch.StartMs).
+			Int("end_ms", ch.EndMs).
+			Msg("encoding chapter")
+
+		var err error
+		if reencode {
+			err = f.runTranscode(args...)
+		} else {
+			err = f.run(args...)
+		}
+		if err != nil {
 			return fmt.Errorf("split chapter %d (%s): %w", i+1, ch.Title, err)
+		}
+
+		decryptLog.Info().
+			Int("chapter", i+1).
+			Int("of", len(chapters)).
+			Str("elapsed", time.Since(chapterStart).Round(time.Second).String()).
+			Msg("chapter encoded")
+
+		if onChapter != nil {
+			onChapter(i+1, len(chapters))
 		}
 	}
 	return nil

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -458,8 +458,16 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 		reencode = true
 	}
 
+	// Compute the minimum zero-pad width so a lexical sort of the output
+	// directory always matches playback order, even for books with 100+
+	// chapters (e.g. 3-digit padding for 100-999 chapters).
+	padWidth := len(fmt.Sprintf("%d", len(chapters)))
+	if padWidth < 2 {
+		padWidth = 2 // always at least "01" for readability
+	}
+
 	for i, ch := range chapters {
-		outputPath := fmt.Sprintf("%s/%02d - %s%s", outputDir, i+1, sanitizeFilename(ch.Title), ext)
+		outputPath := fmt.Sprintf("%s/%0*d - %s%s", outputDir, padWidth, i+1, sanitizeFilename(ch.Title), ext)
 		chapterMeta := meta
 		if strings.TrimSpace(ch.Title) != "" {
 			chapterMeta.Title = ch.Title

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -418,10 +418,22 @@ func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string, me
 		"-f", "concat",
 		"-safe", "0",
 		"-i", listPath,
+	}
+	if meta.CoverPath != "" {
+		args = append(args,
+			"-i", meta.CoverPath,
+			"-map", "0:a",
+			"-map", "1:v",
+			"-c:v", "copy",
+			"-disposition:v:0", "attached_pic",
+		)
+	} else {
+		args = append(args, "-vn")
+	}
+	args = append(args,
 		"-codec:a", "aac",
 		"-b:a", bitrate,
-		"-vn",
-	}
+	)
 	args = append(args, metaArgs...)
 	args = append(args, "-y", outputPath)
 
@@ -464,11 +476,35 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 		args := []string{
 			"-ss", formatDuration(ch.StartMs),
 		}
+		if chapterMeta.CoverPath != "" {
+			args = append(args,
+				"-i", chapterMeta.CoverPath,
+				"-map", "0:a",
+				"-map", "1:v",
+			)
+		}
+		args = append(args, "-ss", formatDuration(ch.StartMs))
 		if ch.EndMs > 0 {
 			args = append(args, "-to", formatDuration(ch.EndMs))
 		}
 		args = append(args, "-i", inputPath)
 		args = append(args, codec...)
+		if chapterMeta.CoverPath != "" {
+			if format == "mp3" {
+				args = append(args,
+					"-c:v", "mjpeg",
+					"-disposition:v:0", "attached_pic",
+					"-id3v2_version", "3",
+					"-metadata:s:v", "title=Album cover",
+					"-metadata:s:v", "comment=Cover (front)",
+				)
+			} else {
+				args = append(args,
+					"-c:v", "copy",
+					"-disposition:v:0", "attached_pic",
+				)
+			}
+		}
 		args = append(args, buildMetadataArgs(chapterMeta)...)
 		args = append(args, "-y", outputPath)
 

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -367,6 +367,52 @@ func (f *FFmpeg) ConvertToMP3(inputPath, outputPath string, bitrate string) erro
 	)
 }
 
+// ConcatToM4B concatenates a list of audio files (in order) into a single
+// M4B output, transcoding to AAC. Used when reassembling chapter-split files
+// back into a single audiobook container.
+func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) error {
+	if len(inputPaths) == 0 {
+		return fmt.Errorf("concat: no input files")
+	}
+	if bitrate == "" {
+		bitrate = "128k"
+	}
+
+	// Build a concat list file in the same directory as the output.
+	listPath := outputPath + ".concat.txt"
+	lf, err := os.Create(listPath)
+	if err != nil {
+		return fmt.Errorf("create concat list: %w", err)
+	}
+	for _, p := range inputPaths {
+		// ffmpeg concat demuxer requires single-quoted absolute paths with
+		// internal quotes escaped per its grammar.
+		escaped := strings.ReplaceAll(p, `'`, `'\''`)
+		if _, err := fmt.Fprintf(lf, "file '%s'\n", escaped); err != nil {
+			lf.Close()
+			os.Remove(listPath)
+			return fmt.Errorf("write concat list: %w", err)
+		}
+	}
+	if err := lf.Close(); err != nil {
+		os.Remove(listPath)
+		return fmt.Errorf("close concat list: %w", err)
+	}
+	defer os.Remove(listPath)
+
+	decryptLog.Info().Int("inputs", len(inputPaths)).Str("output", outputPath).Msg("concatenating chapters into m4b")
+	return f.run(
+		"-f", "concat",
+		"-safe", "0",
+		"-i", listPath,
+		"-codec:a", "aac",
+		"-b:a", bitrate,
+		"-vn",
+		"-y",
+		outputPath,
+	)
+}
+
 // SplitChapters splits an audio file into separate chapter files.
 func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMark, format string) error {
 	decryptLog.Info().Str("input", inputPath).Int("chapters", len(chapters)).Str("format", format).Msg("splitting chapters")

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -476,6 +476,10 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 		args := []string{
 			"-ss", formatDuration(ch.StartMs),
 		}
+		if ch.EndMs > 0 {
+			args = append(args, "-to", formatDuration(ch.EndMs))
+		}
+		args = append(args, "-i", inputPath)
 		if chapterMeta.CoverPath != "" {
 			args = append(args,
 				"-i", chapterMeta.CoverPath,
@@ -483,11 +487,6 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 				"-map", "1:v",
 			)
 		}
-		args = append(args, "-ss", formatDuration(ch.StartMs))
-		if ch.EndMs > 0 {
-			args = append(args, "-to", formatDuration(ch.EndMs))
-		}
-		args = append(args, "-i", inputPath)
 		args = append(args, codec...)
 		if chapterMeta.CoverPath != "" {
 			if format == "mp3" {

--- a/internal/audio/decrypt.go
+++ b/internal/audio/decrypt.go
@@ -381,7 +381,7 @@ func (f *FFmpeg) ConvertToMP3(inputPath, outputPath string, bitrate string) erro
 // ConcatToM4B concatenates a list of audio files (in order) into a single
 // M4B output, transcoding to AAC. Used when reassembling chapter-split files
 // back into a single audiobook container.
-func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) error {
+func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string, meta Metadata) error {
 	if len(inputPaths) == 0 {
 		return fmt.Errorf("concat: no input files")
 	}
@@ -412,16 +412,20 @@ func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) er
 	defer os.Remove(listPath)
 
 	decryptLog.Info().Int("inputs", len(inputPaths)).Str("output", outputPath).Msg("concatenating chapters into m4b")
-	return f.runTranscode(
+	metaArgs := buildMetadataArgs(meta)
+
+	args := []string{
 		"-f", "concat",
 		"-safe", "0",
 		"-i", listPath,
 		"-codec:a", "aac",
 		"-b:a", bitrate,
 		"-vn",
-		"-y",
-		outputPath,
-	)
+	}
+	args = append(args, metaArgs...)
+	args = append(args, "-y", outputPath)
+
+	return f.runTranscode(args...)
 }
 
 // SplitChapters splits an audio file into separate chapter files.
@@ -431,7 +435,7 @@ func (f *FFmpeg) ConcatToM4B(inputPaths []string, outputPath, bitrate string) er
 //
 // onChapter, when non-nil, is invoked after each chapter finishes encoding
 // with (1-based-index, total) so callers can report progress to the UI.
-func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMark, format string, onChapter func(done, total int)) error {
+func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMark, format string, meta Metadata, onChapter func(done, total int)) error {
 	decryptLog.Info().Str("input", inputPath).Int("chapters", len(chapters)).Str("format", format).Msg("splitting chapters")
 	ext := ".m4b"
 	codec := []string{"-c", "copy"}
@@ -444,6 +448,14 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 
 	for i, ch := range chapters {
 		outputPath := fmt.Sprintf("%s/%02d - %s%s", outputDir, i+1, sanitizeFilename(ch.Title), ext)
+		chapterMeta := meta
+		if strings.TrimSpace(ch.Title) != "" {
+			chapterMeta.Title = ch.Title
+		}
+		chapterMeta.Track = fmt.Sprintf("%d/%d", i+1, len(chapters))
+		if chapterMeta.Album == "" {
+			chapterMeta.Album = meta.Title
+		}
 		// -ss/-to MUST come before -i so ffmpeg uses input-side fast seek
 		// (jumps to the byte offset via the container index). Output-side
 		// seek decodes-and-discards from the start of the file, which on a
@@ -457,6 +469,7 @@ func (f *FFmpeg) SplitChapters(inputPath, outputDir string, chapters []ChapterMa
 		}
 		args = append(args, "-i", inputPath)
 		args = append(args, codec...)
+		args = append(args, buildMetadataArgs(chapterMeta)...)
 		args = append(args, "-y", outputPath)
 
 		chapterStart := time.Now()

--- a/internal/audio/ffmpeg.go
+++ b/internal/audio/ffmpeg.go
@@ -48,7 +48,24 @@ func NewFFmpeg(configDir string) (*FFmpeg, error) {
 
 // run executes an ffmpeg command and returns combined output on error.
 func (f *FFmpeg) run(args ...string) error {
-	cmd := exec.Command(f.binPath, args...)
+	return f.runOptions(false, args...)
+}
+
+// runTranscode is run() with -hide_banner / -nostats / -loglevel error
+// added so ffmpeg's stderr stays quiet during long re-encodes. Without
+// these flags ffmpeg fires hundreds of progress lines per second and
+// the parent buffer accumulates into the gigabytes for a 10-hour book.
+func (f *FFmpeg) runTranscode(args ...string) error {
+	return f.runOptions(true, args...)
+}
+
+func (f *FFmpeg) runOptions(quiet bool, args ...string) error {
+	finalArgs := args
+	if quiet {
+		finalArgs = append([]string{"-hide_banner", "-nostats", "-loglevel", "error"}, args...)
+	}
+
+	cmd := exec.Command(f.binPath, finalArgs...)
 
 	// Log command with sensitive info redacted
 	safeArgs := make([]string, len(args))
@@ -62,14 +79,57 @@ func (f *FFmpeg) run(args ...string) error {
 	fullCmd := append([]string{f.binPath}, safeArgs...)
 	ffmpegLog.Debug().Strs("cmd", fullCmd).Msg("executing ffmpeg")
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		ffmpegLog.Error().Err(err).Str("output", strings.TrimSpace(string(output))).Msg("ffmpeg command failed")
-		return fmt.Errorf("ffmpeg failed: %w\noutput: %s", err, strings.TrimSpace(string(output)))
+	// Capture only the tail of stderr (up to 64 KB) on error rather than
+	// buffering the entire stream. ffmpeg's stderr can grow into the
+	// gigabytes during a long re-encode; we only need the last few KB
+	// for diagnostics. Stdout is discarded since these invocations
+	// don't write meaningful stdout (runWithProgress is the path that
+	// captures progress via -progress pipe:1).
+	tail := newTailWriter(64 * 1024)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = tail
+	if err := cmd.Run(); err != nil {
+		out := strings.TrimSpace(tail.String())
+		ffmpegLog.Error().Err(err).Str("output", out).Msg("ffmpeg command failed")
+		return fmt.Errorf("ffmpeg failed: %w\noutput: %s", err, out)
 	}
 	ffmpegLog.Trace().Msg("ffmpeg command succeeded")
 	return nil
 }
+
+// tailWriter is an io.Writer that retains only the last `size` bytes
+// written to it, dropping older bytes from the head. Used to capture a
+// bounded slice of ffmpeg stderr for error reporting without holding
+// the whole stream in memory.
+//
+// Not safe for concurrent Write calls. exec.Cmd serializes writes from
+// a single child's stderr pipe, so this is fine for our use; do not
+// share an instance across goroutines.
+type tailWriter struct {
+	buf []byte
+	max int
+}
+
+func newTailWriter(max int) *tailWriter {
+	return &tailWriter{max: max}
+}
+
+func (t *tailWriter) Write(p []byte) (int, error) {
+	if len(p) >= t.max {
+		// Single write bigger than the window — keep just the tail.
+		t.buf = append(t.buf[:0], p[len(p)-t.max:]...)
+		return len(p), nil
+	}
+	t.buf = append(t.buf, p...)
+	if over := len(t.buf) - t.max; over > 0 {
+		// Slide the window forward by `over` bytes.
+		copy(t.buf, t.buf[over:])
+		t.buf = t.buf[:t.max]
+	}
+	return len(p), nil
+}
+
+func (t *tailWriter) String() string { return string(t.buf) }
 
 // runWithProgress executes ffmpeg with `-progress pipe:1` and streams parsed progress.
 func (f *FFmpeg) runWithProgress(args []string, cb func(ProgressInfo)) error {

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -242,8 +242,9 @@ func (dm *DownloadManager) convertMP3ToM4B(parentCtx, ctx context.Context, book 
 	if len(mp3Files) == 0 {
 		return fmt.Errorf("no mp3 files found in %s", bookDir)
 	}
-	// Filenames are zero-padded by the splitter so a lexical sort matches
-	// playback order (e.g. "01 - ...", "02 - ...").
+	// Filenames are zero-padded by the splitter with a width derived from
+	// the total chapter count, so a lexical sort always matches playback
+	// order regardless of how many chapters the book has.
 	sort.Strings(mp3Files)
 
 	// Stage the concat output in the download dir so a failure leaves the

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -1,0 +1,217 @@
+package library
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mstrhakr/audplexus/internal/audnexus"
+	"github.com/mstrhakr/audplexus/internal/database"
+	"github.com/mstrhakr/audplexus/internal/logging"
+)
+
+// ConvertBook converts an already-organized book between single-file m4b and
+// chapter-split mp3 layouts. The book's on-disk files are replaced in place
+// and its database record is updated to point at the new layout.
+//
+// targetFormat must be "m4b" or "mp3"; if it already matches the current
+// layout the call is a no-op.
+func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, targetFormat string) error {
+	targetFormat = strings.ToLower(strings.TrimSpace(targetFormat))
+	if targetFormat != "m4b" && targetFormat != "mp3" {
+		return fmt.Errorf("invalid target format %q (must be m4b or mp3)", targetFormat)
+	}
+
+	book, err := dm.db.GetBook(ctx, bookID)
+	if err != nil {
+		return fmt.Errorf("load book: %w", err)
+	}
+	if book == nil {
+		return fmt.Errorf("book not found")
+	}
+	if book.FilePath == "" {
+		return fmt.Errorf("book has no file on disk")
+	}
+
+	asinLog := dlLog.WithField("asin", book.ASIN)
+
+	// Detect current layout: if FilePath is a directory we treat it as a
+	// chapter-split layout; if it's a file we use its extension.
+	fi, err := os.Stat(book.FilePath)
+	if err != nil {
+		return fmt.Errorf("stat book path: %w", err)
+	}
+
+	currentFormat := "m4b"
+	bookDir := book.FilePath
+	if fi.IsDir() {
+		currentFormat = "mp3"
+	} else {
+		bookDir = filepath.Dir(book.FilePath)
+		if ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(book.FilePath), ".")); ext == "mp3" {
+			currentFormat = "mp3"
+		}
+	}
+
+	if currentFormat == targetFormat {
+		return fmt.Errorf("book is already in %s format", targetFormat)
+	}
+
+	// Refresh metadata so we have chapter marks (m4b → mp3) or canonical
+	// titles (mp3 → m4b) without trusting the cached DB row alone.
+	enriched, enrichErr := dm.audnexus.EnrichMetadata(ctx, book)
+	if enrichErr != nil {
+		asinLog.Warn().Err(enrichErr).Msg("audnexus enrichment failed during convert; using db metadata only")
+		enriched = &audnexus.EnrichedBook{Book: book}
+	}
+
+	dm.emit(DownloadEvent{ASIN: book.ASIN, BookID: book.ID, Title: book.Title, Type: "stage", Stage: "converting"})
+
+	switch targetFormat {
+	case "mp3":
+		return dm.convertM4BToMP3(ctx, book, enriched, bookDir, asinLog)
+	case "m4b":
+		return dm.convertMP3ToM4B(ctx, book, enriched, bookDir, asinLog)
+	}
+	return nil
+}
+
+func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
+	chapters := enriched.ChapterMarks()
+	if len(chapters) == 0 {
+		return fmt.Errorf("no chapter data available for ASIN %s; cannot split into mp3", book.ASIN)
+	}
+
+	srcM4B := book.FilePath
+
+	// Stage chapter mp3s alongside the source so a failure leaves the original
+	// m4b untouched until we've fully built the replacement set.
+	stageDir := filepath.Join(dm.downloadDir, book.ASIN+".convert-mp3")
+	if err := os.RemoveAll(stageDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("clean stage dir: %w", err)
+	}
+	if err := os.MkdirAll(stageDir, 0750); err != nil {
+		return fmt.Errorf("create stage dir: %w", err)
+	}
+	defer os.RemoveAll(stageDir)
+
+	asinLog.Info().Int("chapters", len(chapters)).Str("stage_dir", stageDir).Msg("convert: splitting m4b into mp3 chapters")
+	if err := dm.ffmpeg.SplitChapters(srcM4B, stageDir, chapters, "mp3"); err != nil {
+		return fmt.Errorf("split chapters: %w", err)
+	}
+
+	// Move staged mp3 files into the existing book directory; on success
+	// remove the source m4b and any sibling .chapters.txt that named it.
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		return fmt.Errorf("read stage dir: %w", err)
+	}
+
+	moved := make([]string, 0, len(entries))
+	var totalBytes int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		src := filepath.Join(stageDir, e.Name())
+		dst := filepath.Join(bookDir, e.Name())
+		if err := os.Rename(src, dst); err != nil {
+			// Roll back any files already moved into the book dir.
+			for _, m := range moved {
+				_ = os.Remove(m)
+			}
+			return fmt.Errorf("move chapter %q: %w", e.Name(), err)
+		}
+		moved = append(moved, dst)
+		if fi, err := os.Stat(dst); err == nil {
+			totalBytes += fi.Size()
+		}
+	}
+
+	if err := os.Remove(srcM4B); err != nil && !os.IsNotExist(err) {
+		asinLog.Warn().Err(err).Str("path", srcM4B).Msg("failed to remove original m4b after convert")
+	}
+
+	book.FilePath = bookDir
+	book.FileSize = totalBytes
+	book.Status = database.BookStatusComplete
+	if err := dm.db.UpsertBook(ctx, book); err != nil {
+		return fmt.Errorf("update book record: %w", err)
+	}
+
+	asinLog.Info().Str("path", bookDir).Int("chapters", len(moved)).Msg("convert m4b→mp3 complete")
+	dm.triggerPlexScanForBook(bookDir)
+	dm.emit(DownloadEvent{
+		ASIN:     book.ASIN,
+		BookID:   book.ID,
+		Title:    book.Title,
+		Type:     "complete",
+		Stage:    "complete",
+		Progress: 1.0,
+	})
+	return nil
+}
+
+func (dm *DownloadManager) convertMP3ToM4B(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
+	entries, err := os.ReadDir(bookDir)
+	if err != nil {
+		return fmt.Errorf("read book dir: %w", err)
+	}
+
+	mp3Files := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(e.Name()), ".mp3") {
+			mp3Files = append(mp3Files, filepath.Join(bookDir, e.Name()))
+		}
+	}
+	if len(mp3Files) == 0 {
+		return fmt.Errorf("no mp3 files found in %s", bookDir)
+	}
+	// Filenames are zero-padded by the splitter so a lexical sort matches
+	// playback order (e.g. "01 - ...", "02 - ...").
+	sort.Strings(mp3Files)
+
+	// Stage the concat output in the download dir so a failure leaves the
+	// existing mp3 layout intact.
+	stagePath := filepath.Join(dm.downloadDir, book.ASIN+".convert.m4b")
+	defer os.Remove(stagePath)
+
+	asinLog.Info().Int("inputs", len(mp3Files)).Str("output", stagePath).Msg("convert: concatenating mp3 chapters into m4b")
+	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k"); err != nil {
+		return fmt.Errorf("concat to m4b: %w", err)
+	}
+
+	// Reuse the organizer's filename builder via Organize so the resulting
+	// file lands with the canonical Plex naming. We hand it the staged m4b
+	// and an empty-but-correct book record; it will move/rename in place.
+	finalPath, err := dm.organizer.Organize(ctx, book, enriched, stagePath)
+	if err != nil {
+		return fmt.Errorf("organize converted m4b: %w", err)
+	}
+
+	// Remove the per-chapter mp3 files now that the m4b is in place.
+	for _, p := range mp3Files {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			asinLog.Warn().Err(err).Str("path", p).Msg("failed to remove chapter mp3 after convert")
+		}
+	}
+
+	asinLog.Info().Str("path", finalPath).Msg("convert mp3→m4b complete")
+	dm.triggerPlexScanForBook(finalPath)
+	dm.emit(DownloadEvent{
+		ASIN:     book.ASIN,
+		BookID:   book.ID,
+		Title:    book.Title,
+		Type:     "complete",
+		Stage:    "complete",
+		Progress: 1.0,
+	})
+
+	return nil
+}

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -143,7 +143,10 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 	}
 
 	asinLog.Info().Str("path", bookDir).Int("chapters", len(moved)).Msg("convert m4b→mp3 complete")
-	dm.triggerPlexScanForBook(bookDir)
+	if dm.mediaServer != nil {
+		dm.mediaServer.TriggerScanForBook(bookDir)
+		dm.mediaServer.EnsureBookInSeriesCollection(enriched.Series(), enriched.Title())
+	}
 	dm.emit(DownloadEvent{
 		ASIN:     book.ASIN,
 		BookID:   book.ID,
@@ -203,7 +206,10 @@ func (dm *DownloadManager) convertMP3ToM4B(ctx context.Context, book *database.B
 	}
 
 	asinLog.Info().Str("path", finalPath).Msg("convert mp3→m4b complete")
-	dm.triggerPlexScanForBook(finalPath)
+	if dm.mediaServer != nil {
+		dm.mediaServer.TriggerScanForBook(finalPath)
+		dm.mediaServer.EnsureBookInSeriesCollection(enriched.Series(), enriched.Title())
+	}
 	dm.emit(DownloadEvent{
 		ASIN:     book.ASIN,
 		BookID:   book.ID,

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -2,7 +2,9 @@ package library
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,12 +15,17 @@ import (
 	"github.com/mstrhakr/audplexus/internal/logging"
 )
 
+// ErrConvertInProgress is returned when a convert is already running for
+// the same book; the caller should retry once the in-flight conversion
+// finishes rather than racing on shared staging directories.
+var ErrConvertInProgress = errors.New("convert already in progress for this book")
+
 // ConvertBook converts an already-organized book between single-file m4b and
 // chapter-split mp3 layouts. The book's on-disk files are replaced in place
 // and its database record is updated to point at the new layout.
 //
-// targetFormat must be "m4b" or "mp3"; if it already matches the current
-// layout the call is a no-op.
+// If the book is already in targetFormat the call is a no-op (success).
+// Concurrent ConvertBook calls for the same book return ErrConvertInProgress.
 func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, targetFormat string) error {
 	targetFormat = strings.ToLower(strings.TrimSpace(targetFormat))
 	if targetFormat != "m4b" && targetFormat != "mp3" {
@@ -35,6 +42,21 @@ func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, target
 	if book.FilePath == "" {
 		return fmt.Errorf("book has no file on disk")
 	}
+
+	// Per-ASIN lock: reject (don't queue) duplicate requests so two clicks
+	// can't race on the same staging directories.
+	dm.convertMu.Lock()
+	if _, busy := dm.convertingASINs[book.ASIN]; busy {
+		dm.convertMu.Unlock()
+		return ErrConvertInProgress
+	}
+	dm.convertingASINs[book.ASIN] = struct{}{}
+	dm.convertMu.Unlock()
+	defer func() {
+		dm.convertMu.Lock()
+		delete(dm.convertingASINs, book.ASIN)
+		dm.convertMu.Unlock()
+	}()
 
 	asinLog := dlLog.WithField("asin", book.ASIN)
 
@@ -57,7 +79,8 @@ func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, target
 	}
 
 	if currentFormat == targetFormat {
-		return fmt.Errorf("book is already in %s format", targetFormat)
+		asinLog.Info().Str("format", targetFormat).Msg("convert no-op: book is already in target format")
+		return nil
 	}
 
 	// Refresh metadata so we have chapter marks (m4b → mp3) or canonical
@@ -77,6 +100,51 @@ func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, target
 		return dm.convertMP3ToM4B(ctx, book, enriched, bookDir, asinLog)
 	}
 	return nil
+}
+
+// moveFileCrossFS moves src to dst, falling back to copy+delete if Rename
+// returns an EXDEV (cross-device) error. PlexOrganizer uses the same pattern
+// for its primary move; we replicate it here so convert works when downloads
+// and library are on different filesystems.
+func moveFileCrossFS(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !isCrossDeviceErr(err) {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(dst)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(dst)
+		return err
+	}
+	return os.Remove(src)
+}
+
+// isCrossDeviceErr reports whether err is the "invalid cross-device link"
+// (EXDEV) error returned by os.Rename when src and dst live on different
+// filesystems. We string-match because the syscall errno isn't exposed
+// portably across Linux/Windows.
+func isCrossDeviceErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "cross-device") || strings.Contains(msg, "different drive") || strings.Contains(msg, "EXDEV")
 }
 
 func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
@@ -118,7 +186,7 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 		}
 		src := filepath.Join(stageDir, e.Name())
 		dst := filepath.Join(bookDir, e.Name())
-		if err := os.Rename(src, dst); err != nil {
+		if err := moveFileCrossFS(src, dst); err != nil {
 			// Roll back any files already moved into the book dir.
 			for _, m := range moved {
 				_ = os.Remove(m)

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -135,53 +134,9 @@ func (dm *DownloadManager) runConvert(parentCtx, ctx context.Context, book *data
 	}
 	return nil
 }
-
-// moveFileCrossFS moves src to dst, falling back to copy+delete if Rename
-// returns an EXDEV (cross-device) error. PlexOrganizer uses the same pattern
-// for its primary move; we replicate it here so convert works when downloads
-// and library are on different filesystems.
-func moveFileCrossFS(src, dst string) error {
-	if err := os.Rename(src, dst); err == nil {
-		return nil
-	} else if !isCrossDeviceErr(err) {
-		return err
-	}
-
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(dst)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		os.Remove(dst)
-		return err
-	}
-	return os.Remove(src)
-}
-
-// isCrossDeviceErr reports whether err is the "invalid cross-device link"
-// (EXDEV) error returned by os.Rename when src and dst live on different
-// filesystems. We string-match because the syscall errno isn't exposed
-// portably across Linux/Windows.
-func isCrossDeviceErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "cross-device") || strings.Contains(msg, "different drive") || strings.Contains(msg, "EXDEV")
-}
-
 func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
+	_ = parentCtx
+	_ = bookDir
 	chapters := enriched.ChapterMarks()
 	meta := enriched.ToAudioMetadata()
 	if len(chapters) == 0 {
@@ -225,71 +180,20 @@ func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book 
 		return fmt.Errorf("split chapters: %w", err)
 	}
 
-	// Move staged mp3 files into the existing book directory; on success
-	// remove the source m4b and any sibling .chapters.txt that named it.
-	entries, err := os.ReadDir(stageDir)
+	// Reuse organizer multi-file flow so mp3 conversion gets the same
+	// companion metadata (.plexmatch/.chapters.txt) and DB update behavior
+	// as pipeline chapter-split output.
+	finalPath, err := dm.organizer.OrganizeMultiFile(ctx, book, enriched, stageDir, nil)
 	if err != nil {
-		return fmt.Errorf("read stage dir: %w", err)
-	}
-
-	moved := make([]string, 0, len(entries))
-	var totalBytes int64
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		// Honor user cancel between chapters so a stuck or slow move
-		// can be aborted without waiting for the whole loop.
-		if err := ctx.Err(); err != nil {
-			for _, m := range moved {
-				_ = os.Remove(m)
-			}
-			if errors.Is(err, context.Canceled) {
-				return fmt.Errorf("cancelled by user")
-			}
-			return err
-		}
-		src := filepath.Join(stageDir, e.Name())
-		dst := filepath.Join(bookDir, e.Name())
-		if err := moveFileCrossFS(src, dst); err != nil {
-			// Roll back any files already moved into the book dir.
-			for _, m := range moved {
-				_ = os.Remove(m)
-			}
-			return fmt.Errorf("move chapter %q: %w", e.Name(), err)
-		}
-		moved = append(moved, dst)
-		if fi, err := os.Stat(dst); err == nil {
-			totalBytes += fi.Size()
-		}
-	}
-
-	// Commit the new layout to the DB BEFORE removing the source m4b.
-	// Two reasons:
-	//   1) If the user cancels right here, the m4b is still on disk and
-	//      DB still references it — recoverable in-place state.
-	//   2) The diagnostics scanner runs against book.FilePath; if we
-	//      delete the m4b first then crash before UpsertBook, the book
-	//      shows up as "missing on disk" until the next reconcile.
-	// Use a detached context so neither user-cancel of the per-item ctx
-	// nor parent shutdown can break the commit and leave the DB
-	// pointing at a deleted file. We've already done the work; the
-	// final write must land.
-	finalizeCtx := context.WithoutCancel(parentCtx)
-	book.FilePath = bookDir
-	book.FileSize = totalBytes
-	book.Status = database.BookStatusComplete
-	if err := dm.db.UpsertBook(finalizeCtx, book); err != nil {
-		// Roll back the chapter file moves so the original m4b layout
-		// is intact for the next attempt.
-		for _, m := range moved {
-			_ = os.Remove(m)
-		}
-		return fmt.Errorf("update book record: %w", err)
+		return fmt.Errorf("organize chapter files: %w", err)
 	}
 
 	if err := os.Remove(srcM4B); err != nil && !os.IsNotExist(err) {
 		asinLog.Warn().Err(err).Str("path", srcM4B).Msg("failed to remove original m4b after convert")
+	}
+	chaptersPath := strings.TrimSuffix(srcM4B, filepath.Ext(srcM4B)) + ".chapters.txt"
+	if err := os.Remove(chaptersPath); err != nil && !os.IsNotExist(err) {
+		asinLog.Warn().Err(err).Str("path", chaptersPath).Msg("failed to remove stale chapters metadata after convert")
 	}
 
 	dm.emit(DownloadEvent{
@@ -301,9 +205,9 @@ func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book 
 		Progress: 1.0,
 	})
 
-	asinLog.Info().Str("path", bookDir).Int("chapters", len(moved)).Msg("convert m4b→mp3 complete")
+	asinLog.Info().Str("path", finalPath).Msg("convert m4b→mp3 complete")
 	if dm.mediaServer != nil {
-		dm.mediaServer.TriggerScanForBook(bookDir)
+		dm.mediaServer.TriggerScanForBook(finalPath)
 		dm.mediaServer.EnsureBookInSeriesCollection(enriched.Series(), enriched.Title())
 	}
 	dm.emit(DownloadEvent{

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -26,13 +26,13 @@ var ErrConvertInProgress = errors.New("convert already in progress for this book
 //
 // If the book is already in targetFormat the call is a no-op (success).
 // Concurrent ConvertBook calls for the same book return ErrConvertInProgress.
-func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, targetFormat string) error {
+func (dm *DownloadManager) ConvertBook(parentCtx context.Context, bookID int64, targetFormat string) error {
 	targetFormat = strings.ToLower(strings.TrimSpace(targetFormat))
 	if targetFormat != "m4b" && targetFormat != "mp3" {
 		return fmt.Errorf("invalid target format %q (must be m4b or mp3)", targetFormat)
 	}
 
-	book, err := dm.db.GetBook(ctx, bookID)
+	book, err := dm.db.GetBook(parentCtx, bookID)
 	if err != nil {
 		return fmt.Errorf("load book: %w", err)
 	}
@@ -58,7 +58,41 @@ func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, target
 		dm.convertMu.Unlock()
 	}()
 
+	// Per-item cancel: register so the user can abort this convert from
+	// the UI via the same Cancel-active endpoint as a stuck download.
+	// parentCtx is preserved separately so the final UpsertBook still
+	// commits even if the user cancels mid-flight.
+	ctx, cancelItem := context.WithCancel(parentCtx)
+	cancelTok := dm.registerActiveCancel(book.ASIN, cancelItem)
+	defer func() {
+		dm.unregisterActiveCancel(book.ASIN, cancelTok)
+		cancelItem()
+	}()
+
 	asinLog := dlLog.WithField("asin", book.ASIN)
+
+	// Emit a failed event over SSE on any error path so the Pipeline
+	// page can clear the active card. Without this the card sticks at
+	// whatever progress the last event reported.
+	convertErr := dm.runConvert(parentCtx, ctx, book, targetFormat, asinLog)
+	if convertErr != nil {
+		dm.emit(DownloadEvent{
+			ASIN:   book.ASIN,
+			BookID: book.ID,
+			Title:  book.Title,
+			Type:   "failed",
+			Stage:  "converting",
+			Error:  convertErr.Error(),
+		})
+	}
+	return convertErr
+}
+
+// runConvert performs the convert under both the parent context (used for
+// final DB writes that must succeed even on cancel) and a per-item context
+// (used for the heavy ffmpeg work that should be cancellable). It returns
+// the first error encountered so the caller can surface it to SSE.
+func (dm *DownloadManager) runConvert(parentCtx, ctx context.Context, book *database.Book, targetFormat string, asinLog *logging.Logger) error {
 
 	// Detect current layout: if FilePath is a directory we treat it as a
 	// chapter-split layout; if it's a file we use its extension.
@@ -95,9 +129,9 @@ func (dm *DownloadManager) ConvertBook(ctx context.Context, bookID int64, target
 
 	switch targetFormat {
 	case "mp3":
-		return dm.convertM4BToMP3(ctx, book, enriched, bookDir, asinLog)
+		return dm.convertM4BToMP3(parentCtx, ctx, book, enriched, bookDir, asinLog)
 	case "m4b":
-		return dm.convertMP3ToM4B(ctx, book, enriched, bookDir, asinLog)
+		return dm.convertMP3ToM4B(parentCtx, ctx, book, enriched, bookDir, asinLog)
 	}
 	return nil
 }
@@ -147,7 +181,7 @@ func isCrossDeviceErr(err error) bool {
 	return strings.Contains(msg, "cross-device") || strings.Contains(msg, "different drive") || strings.Contains(msg, "EXDEV")
 }
 
-func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
+func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
 	chapters := enriched.ChapterMarks()
 	if len(chapters) == 0 {
 		return fmt.Errorf("no chapter data available for ASIN %s; cannot split into mp3", book.ASIN)
@@ -167,7 +201,26 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 	defer os.RemoveAll(stageDir)
 
 	asinLog.Info().Int("chapters", len(chapters)).Str("stage_dir", stageDir).Msg("convert: splitting m4b into mp3 chapters")
-	if err := dm.ffmpeg.SplitChapters(srcM4B, stageDir, chapters, "mp3"); err != nil {
+	onChapter := func(done, total int) {
+		progress := 0.0
+		if total > 0 {
+			// Reserve the last 5% of the bar for the move/finalize step
+			// so users can tell encoding from the file move that follows.
+			progress = float64(done) / float64(total) * 0.95
+		}
+		dm.emit(DownloadEvent{
+			ASIN:     book.ASIN,
+			BookID:   book.ID,
+			Title:    book.Title,
+			Type:     "progress",
+			Stage:    "converting",
+			Progress: progress,
+		})
+	}
+	if err := dm.ffmpeg.SplitChapters(srcM4B, stageDir, chapters, "mp3", onChapter); err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return fmt.Errorf("cancelled by user")
+		}
 		return fmt.Errorf("split chapters: %w", err)
 	}
 
@@ -184,6 +237,17 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 		if e.IsDir() {
 			continue
 		}
+		// Honor user cancel between chapters so a stuck or slow move
+		// can be aborted without waiting for the whole loop.
+		if err := ctx.Err(); err != nil {
+			for _, m := range moved {
+				_ = os.Remove(m)
+			}
+			if errors.Is(err, context.Canceled) {
+				return fmt.Errorf("cancelled by user")
+			}
+			return err
+		}
 		src := filepath.Join(stageDir, e.Name())
 		dst := filepath.Join(bookDir, e.Name())
 		if err := moveFileCrossFS(src, dst); err != nil {
@@ -199,16 +263,42 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 		}
 	}
 
+	// Commit the new layout to the DB BEFORE removing the source m4b.
+	// Two reasons:
+	//   1) If the user cancels right here, the m4b is still on disk and
+	//      DB still references it — recoverable in-place state.
+	//   2) The diagnostics scanner runs against book.FilePath; if we
+	//      delete the m4b first then crash before UpsertBook, the book
+	//      shows up as "missing on disk" until the next reconcile.
+	// Use a detached context so neither user-cancel of the per-item ctx
+	// nor parent shutdown can break the commit and leave the DB
+	// pointing at a deleted file. We've already done the work; the
+	// final write must land.
+	finalizeCtx := context.WithoutCancel(parentCtx)
+	book.FilePath = bookDir
+	book.FileSize = totalBytes
+	book.Status = database.BookStatusComplete
+	if err := dm.db.UpsertBook(finalizeCtx, book); err != nil {
+		// Roll back the chapter file moves so the original m4b layout
+		// is intact for the next attempt.
+		for _, m := range moved {
+			_ = os.Remove(m)
+		}
+		return fmt.Errorf("update book record: %w", err)
+	}
+
 	if err := os.Remove(srcM4B); err != nil && !os.IsNotExist(err) {
 		asinLog.Warn().Err(err).Str("path", srcM4B).Msg("failed to remove original m4b after convert")
 	}
 
-	book.FilePath = bookDir
-	book.FileSize = totalBytes
-	book.Status = database.BookStatusComplete
-	if err := dm.db.UpsertBook(ctx, book); err != nil {
-		return fmt.Errorf("update book record: %w", err)
-	}
+	dm.emit(DownloadEvent{
+		ASIN:     book.ASIN,
+		BookID:   book.ID,
+		Title:    book.Title,
+		Type:     "progress",
+		Stage:    "converting",
+		Progress: 1.0,
+	})
 
 	asinLog.Info().Str("path", bookDir).Int("chapters", len(moved)).Msg("convert m4b→mp3 complete")
 	if dm.mediaServer != nil {
@@ -226,7 +316,7 @@ func (dm *DownloadManager) convertM4BToMP3(ctx context.Context, book *database.B
 	return nil
 }
 
-func (dm *DownloadManager) convertMP3ToM4B(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
+func (dm *DownloadManager) convertMP3ToM4B(parentCtx, ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
 	entries, err := os.ReadDir(bookDir)
 	if err != nil {
 		return fmt.Errorf("read book dir: %w", err)
@@ -254,19 +344,44 @@ func (dm *DownloadManager) convertMP3ToM4B(ctx context.Context, book *database.B
 	defer os.Remove(stagePath)
 
 	asinLog.Info().Int("inputs", len(mp3Files)).Str("output", stagePath).Msg("convert: concatenating mp3 chapters into m4b")
+	// ConcatToM4B is one long ffmpeg call without per-byte progress;
+	// emit start/finish markers so the UI shows activity.
+	dm.emit(DownloadEvent{
+		ASIN:     book.ASIN,
+		BookID:   book.ID,
+		Title:    book.Title,
+		Type:     "progress",
+		Stage:    "converting",
+		Progress: 0.05,
+	})
 	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k"); err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return fmt.Errorf("cancelled by user")
+		}
 		return fmt.Errorf("concat to m4b: %w", err)
 	}
+	dm.emit(DownloadEvent{
+		ASIN:     book.ASIN,
+		BookID:   book.ID,
+		Title:    book.Title,
+		Type:     "progress",
+		Stage:    "converting",
+		Progress: 0.95,
+	})
 
 	// Reuse the organizer's filename builder via Organize so the resulting
-	// file lands with the canonical Plex naming. We hand it the staged m4b
-	// and an empty-but-correct book record; it will move/rename in place.
-	finalPath, err := dm.organizer.Organize(ctx, book, enriched, stagePath)
+	// file lands with the canonical Plex naming. Use a detached context
+	// for the same reason as convertM4BToMP3's finalize: the encode is
+	// done, the move and DB write must land regardless of cancel state.
+	// (Organize itself doesn't use ctx for the file move.)
+	finalPath, err := dm.organizer.Organize(context.WithoutCancel(parentCtx), book, enriched, stagePath)
 	if err != nil {
 		return fmt.Errorf("organize converted m4b: %w", err)
 	}
 
-	// Remove the per-chapter mp3 files now that the m4b is in place.
+	// Only remove the per-chapter mp3 files after the DB update inside
+	// Organize has committed; that way a crash here leaves both layouts
+	// on disk and the DB pointing at the new one (recoverable).
 	for _, p := range mp3Files {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			asinLog.Warn().Err(err).Str("path", p).Msg("failed to remove chapter mp3 after convert")

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -138,7 +138,10 @@ func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book 
 	_ = parentCtx
 	_ = bookDir
 	chapters := enriched.ChapterMarks()
-	meta := enriched.ToAudioMetadata()
+	meta, coverPath := dm.metadataWithOptionalCover(ctx, book.ASIN, enriched)
+	if coverPath != "" {
+		defer os.Remove(coverPath)
+	}
 	if len(chapters) == 0 {
 		return fmt.Errorf("no chapter data available for ASIN %s; cannot split into mp3", book.ASIN)
 	}
@@ -247,6 +250,10 @@ func (dm *DownloadManager) convertMP3ToM4B(parentCtx, ctx context.Context, book 
 	// existing mp3 layout intact.
 	stagePath := filepath.Join(dm.downloadDir, book.ASIN+".convert.m4b")
 	defer os.Remove(stagePath)
+	meta, coverPath := dm.metadataWithOptionalCover(ctx, book.ASIN, enriched)
+	if coverPath != "" {
+		defer os.Remove(coverPath)
+	}
 
 	asinLog.Info().Int("inputs", len(mp3Files)).Str("output", stagePath).Msg("convert: concatenating mp3 chapters into m4b")
 	// ConcatToM4B is one long ffmpeg call without per-byte progress;
@@ -259,7 +266,7 @@ func (dm *DownloadManager) convertMP3ToM4B(parentCtx, ctx context.Context, book 
 		Stage:    "converting",
 		Progress: 0.05,
 	})
-	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k", enriched.ToAudioMetadata()); err != nil {
+	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k", meta); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return fmt.Errorf("cancelled by user")
 		}

--- a/internal/library/convert.go
+++ b/internal/library/convert.go
@@ -183,6 +183,7 @@ func isCrossDeviceErr(err error) bool {
 
 func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, bookDir string, asinLog *logging.Logger) error {
 	chapters := enriched.ChapterMarks()
+	meta := enriched.ToAudioMetadata()
 	if len(chapters) == 0 {
 		return fmt.Errorf("no chapter data available for ASIN %s; cannot split into mp3", book.ASIN)
 	}
@@ -217,7 +218,7 @@ func (dm *DownloadManager) convertM4BToMP3(parentCtx, ctx context.Context, book 
 			Progress: progress,
 		})
 	}
-	if err := dm.ffmpeg.SplitChapters(srcM4B, stageDir, chapters, "mp3", onChapter); err != nil {
+	if err := dm.ffmpeg.SplitChapters(srcM4B, stageDir, chapters, "mp3", meta, onChapter); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return fmt.Errorf("cancelled by user")
 		}
@@ -354,7 +355,7 @@ func (dm *DownloadManager) convertMP3ToM4B(parentCtx, ctx context.Context, book 
 		Stage:    "converting",
 		Progress: 0.05,
 	})
-	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k"); err != nil {
+	if err := dm.ffmpeg.ConcatToM4B(mp3Files, stagePath, "128k", enriched.ToAudioMetadata()); err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return fmt.Errorf("cancelled by user")
 		}

--- a/internal/library/download.go
+++ b/internal/library/download.go
@@ -71,6 +71,12 @@ type DownloadManager struct {
 	activeByASIN   map[string]PipelineStateItem
 	waitingDecrypt map[string]PipelineStateItem
 	waitingMoving  map[string]PipelineStateItem
+
+	// convertMu guards convertingASINs so only one ConvertBook call runs per
+	// book at a time; concurrent requests for the same ASIN are rejected
+	// rather than racing on shared staging directories.
+	convertMu       sync.Mutex
+	convertingASINs map[string]struct{}
 }
 
 // PipelineStateItem is a live in-memory view of one item in the pipeline.
@@ -339,6 +345,7 @@ func NewDownloadManager(
 		activeByASIN:        make(map[string]PipelineStateItem),
 		waitingDecrypt:      make(map[string]PipelineStateItem),
 		waitingMoving:       make(map[string]PipelineStateItem),
+		convertingASINs:     make(map[string]struct{}),
 	}
 }
 

--- a/internal/library/download.go
+++ b/internal/library/download.go
@@ -953,21 +953,7 @@ func (dm *DownloadManager) decryptBook(ctx context.Context, item *pipelineItem, 
 
 	// Output as m4b (decrypted container copy)
 	outputPath := filepath.Join(dm.downloadDir, asin+".m4b")
-	meta := enriched.ToAudioMetadata()
-
-	coverPath := ""
-	dm.mu.Lock()
-	wantCover := dm.embedCover
-	dm.mu.Unlock()
-	if wantCover {
-		downloaded, err := dm.downloadCoverToTemp(ctx, enriched.CoverURL(), asin)
-		if err != nil {
-			dlLog.Warn().Err(err).Str("asin", asin).Msg("cover prefetch failed; continuing without embedded cover")
-		} else {
-			coverPath = downloaded
-			meta.CoverPath = coverPath
-		}
-	}
+	meta, _ := dm.metadataWithOptionalCover(ctx, asin, enriched)
 
 	// Use file size as a stable denominator for decrypt progress.
 	var totalInputBytes int64
@@ -1039,6 +1025,27 @@ func (dm *DownloadManager) decryptBook(ctx context.Context, item *pipelineItem, 
 	}
 
 	return outputPath, nil
+}
+
+func (dm *DownloadManager) metadataWithOptionalCover(ctx context.Context, asin string, enriched *audnexus.EnrichedBook) (audio.Metadata, string) {
+	meta := enriched.ToAudioMetadata()
+
+	dm.mu.Lock()
+	wantCover := dm.embedCover
+	dm.mu.Unlock()
+	if !wantCover {
+		return meta, ""
+	}
+
+	coverPath, err := dm.downloadCoverToTemp(ctx, enriched.CoverURL(), asin)
+	if err != nil {
+		dlLog.Warn().Err(err).Str("asin", asin).Msg("cover prefetch failed; continuing without embedded cover")
+		return meta, ""
+	}
+	if coverPath != "" {
+		meta.CoverPath = coverPath
+	}
+	return meta, coverPath
 }
 
 func (dm *DownloadManager) downloadCoverToTemp(ctx context.Context, coverURL, asin string) (string, error) {

--- a/internal/library/download.go
+++ b/internal/library/download.go
@@ -123,6 +123,28 @@ func (dm *DownloadManager) SetEmbedCover(v bool) {
 	dm.mu.Unlock()
 }
 
+// SetOutputFormat updates the output format setting at runtime.
+// Accepted values are "m4b" and "mp3"; unknown values are ignored.
+func (dm *DownloadManager) SetOutputFormat(v string) {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if v != "m4b" && v != "mp3" {
+		return
+	}
+	dm.mu.Lock()
+	dm.outputFmt = v
+	dm.mu.Unlock()
+}
+
+// OutputFormat returns the current output format ("m4b" or "mp3").
+func (dm *DownloadManager) OutputFormat() string {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	if dm.outputFmt == "" {
+		return "m4b"
+	}
+	return dm.outputFmt
+}
+
 // pipelineItem represents work moving through the pipeline stages.
 type pipelineItem struct {
 	BookID        int64

--- a/internal/library/download.go
+++ b/internal/library/download.go
@@ -72,6 +72,16 @@ type DownloadManager struct {
 	waitingDecrypt map[string]PipelineStateItem
 	waitingMoving  map[string]PipelineStateItem
 
+	// cancelMu guards activeCancels and cancelTokenSeq. Each in-flight
+	// pipeline stage registers a cancel func keyed by ASIN; the
+	// user-facing Cancel-active endpoint looks up the func here to abort
+	// a stuck download/decrypt/process. Tokens distinguish which stage
+	// registered the entry so a late-firing defer from a prior stage
+	// can't delete the current stage's slot.
+	cancelMu       sync.Mutex
+	activeCancels  map[string]activeCancel
+	cancelTokenSeq uint64
+
 	// convertMu guards convertingASINs so only one ConvertBook call runs per
 	// book at a time; concurrent requests for the same ASIN are rejected
 	// rather than racing on shared staging directories.
@@ -149,6 +159,84 @@ func (dm *DownloadManager) OutputFormat() string {
 		return "m4b"
 	}
 	return dm.outputFmt
+}
+
+// cancelToken identifies one registration for a given ASIN. Pipeline stages
+// each get their own token so a late-firing unregister deferred by an
+// earlier stage can't accidentally delete a later stage's entry.
+type cancelToken uint64
+
+// registerActiveCancel stores cancel under asin so CancelActiveDownload can
+// reach it and returns a token the caller passes back to
+// unregisterActiveCancel. If a previous registration is still in place for
+// the same asin (e.g. a defer from a prior pipeline stage hadn't run yet),
+// it is cancelled to avoid leaking the cancel func.
+func (dm *DownloadManager) registerActiveCancel(asin string, cancel context.CancelFunc) cancelToken {
+	if asin == "" {
+		return 0
+	}
+	dm.cancelMu.Lock()
+	if prev, ok := dm.activeCancels[asin]; ok {
+		// Stale entry from a prior stage. Cancel it to release any
+		// resources, then overwrite — this is defensive, the pipeline
+		// shouldn't normally run two stages for one ASIN concurrently.
+		prev.cancel()
+	}
+	dm.cancelTokenSeq++
+	// Skip the 0 sentinel if the counter ever wraps. unregisterActiveCancel
+	// treats token 0 as "no asin" so a wrapped value of 0 would silently
+	// stop guarding against late defers.
+	if dm.cancelTokenSeq == 0 {
+		dm.cancelTokenSeq = 1
+	}
+	tok := cancelToken(dm.cancelTokenSeq)
+	dm.activeCancels[asin] = activeCancel{token: tok, cancel: cancel}
+	dm.cancelMu.Unlock()
+	return tok
+}
+
+// unregisterActiveCancel removes the cancel func for asin only if the
+// stored entry still matches the token returned by registerActiveCancel.
+// This guards against a late defer from a previous stage clobbering the
+// current stage's entry.
+func (dm *DownloadManager) unregisterActiveCancel(asin string, tok cancelToken) {
+	if asin == "" || tok == 0 {
+		return
+	}
+	dm.cancelMu.Lock()
+	if cur, ok := dm.activeCancels[asin]; ok && cur.token == tok {
+		delete(dm.activeCancels, asin)
+	}
+	dm.cancelMu.Unlock()
+}
+
+// CancelActiveDownload aborts the in-flight pipeline stage for the given
+// ASIN by cancelling its context. Returns true if a cancel was issued,
+// false if no active item matched. The pipeline stage handler is
+// responsible for cleaning up partial files when its context is cancelled.
+func (dm *DownloadManager) CancelActiveDownload(asin string) bool {
+	if asin == "" {
+		return false
+	}
+	dm.cancelMu.Lock()
+	entry, ok := dm.activeCancels[asin]
+	if ok {
+		delete(dm.activeCancels, asin)
+	}
+	dm.cancelMu.Unlock()
+	if !ok {
+		return false
+	}
+	entry.cancel()
+	return true
+}
+
+// activeCancel pairs a registered CancelFunc with a generation token so
+// unregisterActiveCancel only deletes its own entry, never one belonging
+// to a later pipeline stage for the same ASIN.
+type activeCancel struct {
+	token  cancelToken
+	cancel context.CancelFunc
 }
 
 // pipelineItem represents work moving through the pipeline stages.
@@ -346,6 +434,7 @@ func NewDownloadManager(
 		waitingDecrypt:      make(map[string]PipelineStateItem),
 		waitingMoving:       make(map[string]PipelineStateItem),
 		convertingASINs:     make(map[string]struct{}),
+		activeCancels:       make(map[string]activeCancel),
 	}
 }
 

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -386,9 +386,11 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 			}
 
 			asinLog.Info().Str("path", finalPath).Msg("pipeline complete (chapter-split)")
-			dm.triggerPlexScanForBook(finalPath)
-			if enriched != nil {
-				dm.addBookToSeriesCollection(enriched.Series(), enriched.Title())
+			if dm.mediaServer != nil {
+				dm.mediaServer.TriggerScanForBook(finalPath)
+				if enriched != nil {
+					dm.mediaServer.EnsureBookInSeriesCollection(enriched.Series(), enriched.Title())
+				}
 			}
 			dm.emit(DownloadEvent{
 				ASIN:     item.ASIN,

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -2,15 +2,23 @@ package library
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/mstrhakr/audplexus/internal/audnexus"
 	"github.com/mstrhakr/audplexus/internal/database"
 )
+
+// downloadStallTimeout is how long the download stage may go without seeing
+// any new bytes before its context is cancelled and the request is treated
+// as a stalled CDN connection. Audible's CDN normally resets within seconds
+// of an actual error, but we've seen connections sit silently for minutes.
+const downloadStallTimeout = 2 * time.Minute
 
 // copyFileSimple copies src to dst, overwriting any existing file. Used for
 // best-effort sidecar writes (e.g. folder.jpg) where progress isn't needed.
@@ -59,15 +67,28 @@ func (dm *DownloadManager) handleDownloadStage(ctx context.Context, item *databa
 		Book:         book,
 	}
 
-	// Start metadata lookup immediately so download starts with metadata fetch.
+	// Per-item cancellable context: lets the user abort this download from
+	// the UI and lets the stall watchdog kill a stuck connection without
+	// taking down the whole worker pool.
+	itemCtx, cancelItem := context.WithCancel(ctx)
+	cancelTok := dm.registerActiveCancel(item.ASIN, cancelItem)
+	defer func() {
+		dm.unregisterActiveCancel(item.ASIN, cancelTok)
+		cancelItem()
+	}()
+
+	// Start metadata lookup immediately. Use the parent worker ctx (not
+	// itemCtx) so the in-flight audnexus calls survive a stall-watchdog
+	// cancel of the download and remain available to decrypt/process,
+	// which depend on chapter data to honor the mp3-split setting.
 	dm.startMetadataPrefetch(ctx, pipeItem)
 
 	// Mark download as active
 	now := time.Now()
 	item.Status = database.DownloadStatusActive
 	item.StartedAt = &now
-	_ = dm.db.UpdateDownload(ctx, item)
-	_ = dm.db.UpdateBookStatus(ctx, item.BookID, database.BookStatusDownloading)
+	_ = dm.db.UpdateDownload(itemCtx, item)
+	_ = dm.db.UpdateBookStatus(itemCtx, item.BookID, database.BookStatusDownloading)
 
 	dm.emit(DownloadEvent{ASIN: item.ASIN, BookID: item.BookID, Title: bookTitle, Type: "started", Stage: "downloading"})
 
@@ -75,11 +96,53 @@ func (dm *DownloadManager) handleDownloadStage(ctx context.Context, item *databa
 	var lastDBWrite time.Time
 	var lastLogPct int
 	downloadStart := time.Now()
+	var bytesSnapshot atomic.Int64
+	var stalled atomic.Bool
+
+	// Stall watchdog: if no new bytes arrive for downloadStallTimeout while
+	// the download is in progress, cancel the item context. The CDN's TCP
+	// keepalive can take 2h to fire, so without this a hung connection
+	// would sit in io.Copy until then.
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		var lastSeen int64
+		var lastSeenAt = time.Now()
+		for {
+			select {
+			case <-itemCtx.Done():
+				return
+			case <-ticker.C:
+				cur := bytesSnapshot.Load()
+				if cur > lastSeen {
+					lastSeen = cur
+					lastSeenAt = time.Now()
+					continue
+				}
+				// Fire whether or not any bytes arrived — a connection
+				// that hangs before the first byte (slow TLS, server
+				// silently dropping the request) is exactly the kind
+				// of stall this watchdog is meant to recover from.
+				if time.Since(lastSeenAt) >= downloadStallTimeout {
+					stalled.Store(true)
+					asinLog.Warn().
+						Int64("bytes", cur).
+						Dur("idle", time.Since(lastSeenAt).Round(time.Second)).
+						Msg("download stalled with no progress; cancelling")
+					cancelItem()
+					return
+				}
+			}
+		}
+	}()
 
 	writer := &fileDownloadWriter{
 		asin:        item.ASIN,
 		downloadDir: dm.downloadDir,
 		onProgress: func(written, total int64) {
+			bytesSnapshot.Store(written)
 			progress := 0.0
 			if total > 0 {
 				progress = float64(written) / float64(total)
@@ -108,7 +171,7 @@ func (dm *DownloadManager) handleDownloadStage(ctx context.Context, item *databa
 			// Persist to DB every 5 seconds
 			if now.Sub(lastDBWrite) >= 5*time.Second {
 				lastDBWrite = now
-				_ = dm.db.UpdateDownload(ctx, item)
+				_ = dm.db.UpdateDownload(itemCtx, item)
 			}
 
 			// SSE to UI every 500ms for smooth progress
@@ -131,8 +194,23 @@ func (dm *DownloadManager) handleDownloadStage(ctx context.Context, item *databa
 		},
 	}
 
-	bytesWritten, err := dm.client.DownloadBook(ctx, item.ASIN, writer)
+	bytesWritten, err := dm.client.DownloadBook(itemCtx, item.ASIN, writer)
+	// Watchdog goroutine winds down once itemCtx is done; wait so it's
+	// fully gone before we exit and cancelItem fires from the deferred
+	// cleanup (avoids a brief leak window if the worker keeps churning).
+	cancelItem()
+	<-watchDone
+
 	if err != nil {
+		// Distinguish a watchdog-initiated stall cancel from a real network
+		// error or a parent-context cancel (queue paused / shutdown) so the
+		// user-facing message is accurate.
+		switch {
+		case stalled.Load():
+			err = fmt.Errorf("download stalled (no progress for %s); cancelled", downloadStallTimeout)
+		case ctx.Err() == nil && errors.Is(err, context.Canceled):
+			err = fmt.Errorf("cancelled by user")
+		}
 		asinLog.Error().Err(err).Msg("download failed")
 		writer.Cleanup()
 		dm.cleanupDownloadFiles(item.ASIN)
@@ -181,9 +259,19 @@ func (dm *DownloadManager) handleDownloadStage(ctx context.Context, item *databa
 }
 
 // handleDecryptStage handles the decryption stage of the pipeline.
-func (dm *DownloadManager) handleDecryptStage(ctx context.Context, item *pipelineItem) {
+func (dm *DownloadManager) handleDecryptStage(parentCtx context.Context, item *pipelineItem) {
 	asinLog := dlLog.WithField("asin", item.ASIN)
 	asinLog.Info().Msg("starting decrypt stage")
+
+	// Per-item cancel: lets the user abort this decrypt from the UI.
+	// parentCtx is preserved separately for cleanup writes (failItem) so
+	// they don't fail just because the user cancelled this item.
+	ctx, cancelItem := context.WithCancel(parentCtx)
+	cancelTok := dm.registerActiveCancel(item.ASIN, cancelItem)
+	defer func() {
+		dm.unregisterActiveCancel(item.ASIN, cancelTok)
+		cancelItem()
+	}()
 
 	_ = dm.db.UpdateBookStatus(ctx, item.BookID, database.BookStatusDecrypting)
 	dm.emit(DownloadEvent{ASIN: item.ASIN, BookID: item.BookID, Title: item.Title, Type: "stage", Stage: "decrypting"})
@@ -198,14 +286,14 @@ func (dm *DownloadManager) handleDecryptStage(ctx context.Context, item *pipelin
 	}
 
 	if item.BookErr != nil {
-		dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", item.BookErr))
+		dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", item.BookErr))
 		return
 	}
 
 	if item.Book == nil {
 		book, err := dm.db.GetBook(ctx, item.BookID)
 		if err != nil {
-			dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", err))
+			dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", err))
 			return
 		}
 		item.Book = book
@@ -221,9 +309,14 @@ func (dm *DownloadManager) handleDecryptStage(ctx context.Context, item *pipelin
 
 	decryptedPath, err := dm.decryptBook(ctx, item, enriched)
 	if err != nil {
+		// If the user cancelled this item, surface that in the failure
+		// message rather than a noisy ffmpeg "context canceled" error.
+		if parentCtx.Err() == nil && errors.Is(err, context.Canceled) {
+			err = fmt.Errorf("cancelled by user")
+		}
 		asinLog.Error().Err(err).Msg("decryption failed")
 		dm.cleanupDownloadFiles(item.ASIN)
-		dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("decrypt: %w", err))
+		dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("decrypt: %w", err))
 		return
 	}
 	item.DecryptedPath = decryptedPath
@@ -259,9 +352,19 @@ func (dm *DownloadManager) handleDecryptStage(ctx context.Context, item *pipelin
 }
 
 // handleProcessStage handles final organization/chapter generation for already-tagged audio.
-func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelineItem) {
+func (dm *DownloadManager) handleProcessStage(parentCtx context.Context, item *pipelineItem) {
 	asinLog := dlLog.WithField("asin", item.ASIN)
 	asinLog.Info().Msg("starting move stage")
+
+	// Per-item cancel: lets the user abort this process step from the UI.
+	// parentCtx stays valid for failItem cleanup writes even if the user
+	// cancels this item mid-flight.
+	ctx, cancelItem := context.WithCancel(parentCtx)
+	cancelTok := dm.registerActiveCancel(item.ASIN, cancelItem)
+	defer func() {
+		dm.unregisterActiveCancel(item.ASIN, cancelTok)
+		cancelItem()
+	}()
 
 	_ = dm.db.UpdateBookStatus(ctx, item.BookID, database.BookStatusProcessing)
 	dm.emit(DownloadEvent{ASIN: item.ASIN, BookID: item.BookID, Title: item.Title, Type: "stage", Stage: "moving"})
@@ -273,7 +376,7 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 		book, err = dm.db.GetBook(ctx, item.BookID)
 		if err != nil {
 			asinLog.Error().Err(err).Msg("failed to load book record")
-			dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", err))
+			dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("load book: %w", err))
 			return
 		}
 	}
@@ -304,20 +407,40 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 			// into the final book folder.
 			if err := os.RemoveAll(stageDir); err != nil && !os.IsNotExist(err) {
 				dm.cleanupDownloadFiles(item.ASIN)
-				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("clean chapter staging dir: %w", err))
+				dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("clean chapter staging dir: %w", err))
 				return
 			}
 			if err := os.MkdirAll(stageDir, 0750); err != nil {
 				dm.cleanupDownloadFiles(item.ASIN)
-				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("create chapter staging dir: %w", err))
+				dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("create chapter staging dir: %w", err))
 				return
 			}
 
 			asinLog.Info().Int("chapters", len(chapters)).Str("stage_dir", stageDir).Msg("splitting into mp3 chapters")
-			if err := dm.ffmpeg.SplitChapters(decryptedPath, stageDir, chapters, "mp3"); err != nil {
+			// Switch the badge to "transcoding" so the UI reflects what we're
+			// actually doing (re-encoding audio, not moving files).
+			dm.emit(DownloadEvent{ASIN: item.ASIN, BookID: item.BookID, Title: item.Title, Type: "stage", Stage: "transcoding"})
+			onChapter := func(done, total int) {
+				progress := 0.0
+				if total > 0 {
+					progress = float64(done) / float64(total)
+				}
+				dm.emit(DownloadEvent{
+					ASIN:     item.ASIN,
+					BookID:   item.BookID,
+					Title:    item.Title,
+					Type:     "progress",
+					Stage:    "transcoding",
+					Progress: progress,
+				})
+			}
+			if err := dm.ffmpeg.SplitChapters(decryptedPath, stageDir, chapters, "mp3", onChapter); err != nil {
 				_ = os.RemoveAll(stageDir)
 				dm.cleanupDownloadFiles(item.ASIN)
-				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("split chapters: %w", err))
+				if parentCtx.Err() == nil && errors.Is(err, context.Canceled) {
+					err = fmt.Errorf("cancelled by user")
+				}
+				dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("split chapters: %w", err))
 				return
 			}
 
@@ -375,7 +498,10 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 			if err != nil {
 				_ = os.RemoveAll(stageDir)
 				dm.cleanupDownloadFiles(item.ASIN)
-				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("organize: %w", err))
+				if parentCtx.Err() == nil && errors.Is(err, context.Canceled) {
+					err = fmt.Errorf("cancelled by user")
+				}
+				dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("organize: %w", err))
 				return
 			}
 			onMoveProgress(totalBytes, totalBytes)
@@ -390,7 +516,9 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 				item.DownloadItem.Progress = 1.0
 				item.DownloadItem.Error = ""
 				item.DownloadItem.CompletedAt = &now
-				_ = dm.db.UpdateDownload(ctx, item.DownloadItem)
+				// Detach: the work is done, the row must commit even if
+				// the worker context is being torn down at shutdown.
+				_ = dm.db.UpdateDownload(context.WithoutCancel(parentCtx), item.DownloadItem)
 			}
 
 			asinLog.Info().Str("path", finalPath).Msg("pipeline complete (chapter-split)")
@@ -462,7 +590,10 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 	if err != nil {
 		asinLog.Error().Err(err).Msg("organization failed")
 		dm.cleanupDownloadFiles(item.ASIN)
-		dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("organize: %w", err))
+		if parentCtx.Err() == nil && errors.Is(err, context.Canceled) {
+			err = fmt.Errorf("cancelled by user")
+		}
+		dm.failItem(parentCtx, item.DownloadItem, item.Title, fmt.Errorf("organize: %w", err))
 		return
 	}
 	onMoveProgress(totalBytes, totalBytes)
@@ -489,7 +620,9 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 		item.DownloadItem.Progress = 1.0
 		item.DownloadItem.Error = ""
 		item.DownloadItem.CompletedAt = &now
-		_ = dm.db.UpdateDownload(ctx, item.DownloadItem)
+		// Detach: the work is done, the row must commit even if the
+		// worker context is being torn down at shutdown.
+		_ = dm.db.UpdateDownload(context.WithoutCancel(parentCtx), item.DownloadItem)
 	}
 
 	asinLog.Info().Str("path", finalPath).Msg("pipeline complete")

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -290,6 +290,118 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 		decryptedPath = filepath.Join(dm.downloadDir, item.ASIN+".m4b")
 	}
 
+	// If the user has selected MP3 (chapter-split) output, transcode the
+	// decrypted m4b into per-chapter mp3 files in a temp staging directory and
+	// then organize that directory into the Plex book folder.
+	if dm.OutputFormat() == "mp3" {
+		chapters := enriched.ChapterMarks()
+		if len(chapters) == 0 {
+			asinLog.Warn().Msg("mp3 chapter-split requested but no chapter data available; falling back to single-file output")
+		} else {
+			stageDir := filepath.Join(dm.downloadDir, item.ASIN+".chapters")
+			if err := os.MkdirAll(stageDir, 0750); err != nil {
+				dm.cleanupDownloadFiles(item.ASIN)
+				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("create chapter staging dir: %w", err))
+				return
+			}
+
+			asinLog.Info().Int("chapters", len(chapters)).Str("stage_dir", stageDir).Msg("splitting into mp3 chapters")
+			if err := dm.ffmpeg.SplitChapters(decryptedPath, stageDir, chapters, "mp3"); err != nil {
+				_ = os.RemoveAll(stageDir)
+				dm.cleanupDownloadFiles(item.ASIN)
+				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("split chapters: %w", err))
+				return
+			}
+
+			// Rough total for progress: sum the staged file sizes.
+			var totalBytes int64
+			if entries, err := os.ReadDir(stageDir); err == nil {
+				for _, e := range entries {
+					if e.IsDir() {
+						continue
+					}
+					if fi, err := e.Info(); err == nil {
+						totalBytes += fi.Size()
+					}
+				}
+			}
+
+			moveStart := time.Now()
+			var lastEmit time.Time
+			onMoveProgress := func(moved, total int64) {
+				now := time.Now()
+				if now.Sub(lastEmit) < 300*time.Millisecond && moved < total {
+					return
+				}
+				lastEmit = now
+
+				if total <= 0 {
+					total = totalBytes
+				}
+				progress := 0.0
+				if total > 0 {
+					progress = float64(moved) / float64(total)
+					if progress > 1 {
+						progress = 1
+					}
+				}
+				speed := 0.0
+				if elapsed := now.Sub(moveStart).Seconds(); elapsed > 0 {
+					speed = float64(moved) / elapsed
+				}
+				dm.emit(DownloadEvent{
+					ASIN:         item.ASIN,
+					BookID:       item.BookID,
+					Title:        item.Title,
+					Type:         "progress",
+					Stage:        "moving",
+					Progress:     progress,
+					BytesWritten: moved,
+					TotalBytes:   total,
+					Speed:        speed,
+				})
+			}
+
+			onMoveProgress(0, totalBytes)
+			finalPath, err := dm.organizer.OrganizeMultiFile(ctx, book, enriched, stageDir, onMoveProgress)
+			if err != nil {
+				_ = os.RemoveAll(stageDir)
+				dm.cleanupDownloadFiles(item.ASIN)
+				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("organize: %w", err))
+				return
+			}
+			onMoveProgress(totalBytes, totalBytes)
+
+			// Best-effort: drop the staging dir and the now-orphan decrypted m4b.
+			_ = os.RemoveAll(stageDir)
+			dm.cleanupDownloadFiles(item.ASIN)
+
+			now := time.Now()
+			if item.DownloadItem != nil {
+				item.DownloadItem.Status = database.DownloadStatusComplete
+				item.DownloadItem.Progress = 1.0
+				item.DownloadItem.Error = ""
+				item.DownloadItem.CompletedAt = &now
+				_ = dm.db.UpdateDownload(ctx, item.DownloadItem)
+			}
+
+			asinLog.Info().Str("path", finalPath).Msg("pipeline complete (chapter-split)")
+			dm.triggerPlexScanForBook(finalPath)
+			if enriched != nil {
+				dm.addBookToSeriesCollection(enriched.Series(), enriched.Title())
+			}
+			dm.emit(DownloadEvent{
+				ASIN:     item.ASIN,
+				BookID:   item.BookID,
+				Title:    item.Title,
+				Type:     "complete",
+				Stage:    "complete",
+				Progress: 1.0,
+			})
+			return
+		}
+	}
+
 	totalBytes := int64(0)
 	if st, err := os.Stat(decryptedPath); err == nil {
 		totalBytes = st.Size()

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -299,6 +299,14 @@ func (dm *DownloadManager) handleProcessStage(ctx context.Context, item *pipelin
 			asinLog.Warn().Msg("mp3 chapter-split requested but no chapter data available; falling back to single-file output")
 		} else {
 			stageDir := filepath.Join(dm.downloadDir, item.ASIN+".chapters")
+			// Clear any leftovers from a previous run; chapter counts can
+			// change across re-runs and stale files would otherwise leak
+			// into the final book folder.
+			if err := os.RemoveAll(stageDir); err != nil && !os.IsNotExist(err) {
+				dm.cleanupDownloadFiles(item.ASIN)
+				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("clean chapter staging dir: %w", err))
+				return
+			}
 			if err := os.MkdirAll(stageDir, 0750); err != nil {
 				dm.cleanupDownloadFiles(item.ASIN)
 				dm.failItem(ctx, item.DownloadItem, item.Title, fmt.Errorf("create chapter staging dir: %w", err))

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -398,7 +398,10 @@ func (dm *DownloadManager) handleProcessStage(parentCtx context.Context, item *p
 	// then organize that directory into the Plex book folder.
 	if dm.OutputFormat() == "mp3" {
 		chapters := enriched.ChapterMarks()
-		meta := enriched.ToAudioMetadata()
+		meta, coverPath := dm.metadataWithOptionalCover(ctx, item.ASIN, enriched)
+		if coverPath != "" {
+			defer os.Remove(coverPath)
+		}
 		if len(chapters) == 0 {
 			asinLog.Warn().Msg("mp3 chapter-split requested but no chapter data available; falling back to single-file output")
 		} else {

--- a/internal/library/pipeline_stages.go
+++ b/internal/library/pipeline_stages.go
@@ -398,6 +398,7 @@ func (dm *DownloadManager) handleProcessStage(parentCtx context.Context, item *p
 	// then organize that directory into the Plex book folder.
 	if dm.OutputFormat() == "mp3" {
 		chapters := enriched.ChapterMarks()
+		meta := enriched.ToAudioMetadata()
 		if len(chapters) == 0 {
 			asinLog.Warn().Msg("mp3 chapter-split requested but no chapter data available; falling back to single-file output")
 		} else {
@@ -434,7 +435,7 @@ func (dm *DownloadManager) handleProcessStage(parentCtx context.Context, item *p
 					Progress: progress,
 				})
 			}
-			if err := dm.ffmpeg.SplitChapters(decryptedPath, stageDir, chapters, "mp3", onChapter); err != nil {
+			if err := dm.ffmpeg.SplitChapters(decryptedPath, stageDir, chapters, "mp3", meta, onChapter); err != nil {
 				_ = os.RemoveAll(stageDir)
 				dm.cleanupDownloadFiles(item.ASIN)
 				if parentCtx.Err() == nil && errors.Is(err, context.Canceled) {

--- a/internal/organizer/plex.go
+++ b/internal/organizer/plex.go
@@ -175,6 +175,144 @@ func (o *PlexOrganizer) OrganizeWithProgress(ctx context.Context, book *database
 	return finalPath, nil
 }
 
+// OrganizeMultiFile takes a directory of per-chapter audio files and moves them
+// into the Plex book folder, preserving each chapter as its own track. The
+// chapter files in srcDir are expected to already be named in playback order
+// (e.g. "01 - Prologue.mp3"); their names are kept verbatim inside the book
+// folder so Plex orders tracks naturally.
+//
+// onMoveProgress reports cumulative bytes moved across all chapter files.
+func (o *PlexOrganizer) OrganizeMultiFile(ctx context.Context, book *database.Book, enriched *audnexus.EnrichedBook, srcDir string, onMoveProgress func(moved, total int64)) (string, error) {
+	_ = ctx
+	author := strings.TrimSpace(enriched.Author())
+	title := strings.TrimSpace(enriched.Title())
+	subtitle := strings.TrimSpace(enriched.Subtitle())
+	series := strings.TrimSpace(enriched.Series())
+	seriesPosition := strings.TrimSpace(enriched.SeriesPosition())
+	asin := strings.TrimSpace(book.ASIN)
+	region := strings.TrimSpace(enriched.Region())
+
+	if author == "" {
+		author = "Unknown Author"
+	}
+	if title == "" {
+		title = "Unknown Title"
+	}
+	filenameBase := buildFilenameBase(title, subtitle, series, seriesPosition, asin, region)
+	bookDirName := buildBookDirectoryName(title, asin, region)
+
+	bookDir := filepath.Join(o.libraryRoot, sanitizePath(author), sanitizePath(bookDirName))
+	if err := os.MkdirAll(bookDir, 0750); err != nil {
+		return "", fmt.Errorf("create book directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return "", fmt.Errorf("read chapter source: %w", err)
+	}
+
+	// Pre-scan to compute total bytes for progress reporting.
+	totalBytes := int64(0)
+	chapterFiles := make([]os.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		chapterFiles = append(chapterFiles, e)
+		if fi, statErr := e.Info(); statErr == nil {
+			totalBytes += fi.Size()
+		}
+	}
+
+	orgLog.Info().
+		Str("asin", book.ASIN).
+		Str("title", enriched.Title()).
+		Str("dest", bookDir).
+		Int("chapters", len(chapterFiles)).
+		Msg("organizing chapter-split audiobook")
+
+	// firstFinal is returned as a representative path for the book record.
+	firstFinal := ""
+	movedTotal := int64(0)
+	for _, e := range chapterFiles {
+		src := filepath.Join(srcDir, e.Name())
+		dst := filepath.Join(bookDir, e.Name())
+
+		fileSize := int64(0)
+		if fi, err := os.Stat(src); err == nil {
+			fileSize = fi.Size()
+		}
+
+		if err := os.Rename(src, dst); err != nil {
+			// Cross-device rename; fall back to copy+delete with sub-file progress.
+			subProgress := func(moved, _ int64) {
+				if onMoveProgress != nil {
+					onMoveProgress(movedTotal+moved, totalBytes)
+				}
+			}
+			if err := copyFile(src, dst, fileSize, subProgress); err != nil {
+				return "", fmt.Errorf("move chapter file %q: %w", e.Name(), err)
+			}
+			_ = os.Remove(src)
+		}
+
+		movedTotal += fileSize
+		if onMoveProgress != nil {
+			onMoveProgress(movedTotal, totalBytes)
+		}
+
+		if firstFinal == "" {
+			firstFinal = dst
+		}
+	}
+
+	if firstFinal == "" {
+		return "", fmt.Errorf("no chapter files found in %s", srcDir)
+	}
+
+	// Generate .plexmatch hint file for perfect Plex library scanning.
+	o.mu.RLock()
+	wantPlexMatch := o.plexMatchFile
+	o.mu.RUnlock()
+	if wantPlexMatch {
+		if err := writePlexMatchFile(bookDir, enriched, book); err != nil {
+			orgLog.Warn().Err(err).Msg("failed to write .plexmatch file")
+		}
+	}
+
+	// Generate chapters file alongside the chapter tracks for tools that read it.
+	o.mu.RLock()
+	wantChapters := o.chapterFile
+	o.mu.RUnlock()
+	if wantChapters {
+		chapters := enriched.ChapterMarks()
+		if len(chapters) > 0 {
+			chapterPath := filepath.Join(bookDir, sanitizePath(filenameBase)+".chapters.txt")
+			if err := writeChaptersFile(chapterPath, chapters); err != nil {
+				orgLog.Warn().Err(err).Msg("failed to write chapters file")
+			}
+		}
+	}
+
+	// Update book in database. For multi-file output we record the directory as
+	// FilePath and the cumulative size of all chapter files.
+	book.FilePath = bookDir
+	book.FileSize = totalBytes
+	book.Status = database.BookStatusComplete
+	if err := o.db.UpsertBook(ctx, book); err != nil {
+		orgLog.Error().Err(err).Str("asin", book.ASIN).Msg("failed to update book record")
+	}
+
+	orgLog.Info().
+		Str("asin", book.ASIN).
+		Str("path", bookDir).
+		Int64("size", totalBytes).
+		Int("chapters", len(chapterFiles)).
+		Msg("audiobook organized successfully (chapter-split)")
+
+	return bookDir, nil
+}
+
 // buildFilenameBase builds a Plex-friendly filename with ASIN and optional region for easier scanning.
 // Output: "Title: Subtitle - SeriesName SeriesPosition ASIN [regionCode]" (subtitle/series/region are optional).
 func buildFilenameBase(title, subtitle, series, seriesPosition, asin, region string) string {

--- a/internal/organizer/plex.go
+++ b/internal/organizer/plex.go
@@ -301,6 +301,7 @@ func (o *PlexOrganizer) OrganizeMultiFile(ctx context.Context, book *database.Bo
 	book.Status = database.BookStatusComplete
 	if err := o.db.UpsertBook(ctx, book); err != nil {
 		orgLog.Error().Err(err).Str("asin", book.ASIN).Msg("failed to update book record")
+		return "", fmt.Errorf("update book record: %w", err)
 	}
 
 	orgLog.Info().

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -287,6 +287,7 @@ func (s *Server) setupRoutes() {
 		api.POST("/downloads/queue-all", s.handleQueueAll)
 		api.POST("/downloads/queue/:asin", s.handleQueueBook)
 		api.POST("/downloads/cancel/:id", s.handleCancelDownload)
+		api.POST("/downloads/cancel-active/:asin", s.handleCancelActiveDownload)
 		api.POST("/downloads/retry/:id", s.handleRetryDownload)
 		api.POST("/downloads/retry-all", s.handleRetryAllDownloads)
 		api.POST("/downloads/pause", s.handlePauseDownloads)
@@ -1286,6 +1287,24 @@ func (s *Server) handleCancelDownload(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "cancelled"})
 }
 
+// handleCancelActiveDownload aborts the in-flight pipeline stage for the
+// given ASIN (download/decrypt/process/convert). Use this when a normal
+// queue cancel can't help because the work is already running and possibly
+// stuck on a stalled network read.
+func (s *Server) handleCancelActiveDownload(c *gin.Context) {
+	asin := strings.TrimSpace(c.Param("asin"))
+	if asin == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing asin"})
+		return
+	}
+	if !s.downloads.CancelActiveDownload(asin) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no active pipeline item for that asin"})
+		return
+	}
+	webLog.Info().Str("asin", asin).Msg("cancelled active pipeline item via UI")
+	c.JSON(http.StatusOK, gin.H{"status": "cancelling"})
+}
+
 // handleRetryDownload resets a failed download back to pending.
 func (s *Server) handleRetryDownload(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -2074,7 +2093,11 @@ func (s *Server) handleRedownload(c *gin.Context) {
 // handleConvertBook converts an existing book between single-file m4b and
 // chapter-split mp3 layouts in place.
 func (s *Server) handleConvertBook(c *gin.Context) {
-	ctx := c.Request.Context()
+	// Convert is a long-running operation; detach from the HTTP request
+	// context so navigating away or closing the tab doesn't cancel the
+	// in-flight transcode. The user can still abort via the Cancel
+	// button which talks to a separate cancel endpoint.
+	ctx := context.Background()
 
 	id, err := strconv.ParseInt(strings.TrimSpace(c.Param("id")), 10, 64)
 	if err != nil || id <= 0 {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -192,6 +192,7 @@ func (s *Server) setupTemplates() {
 			}
 			return template.HTML(htmlPolicy.Sanitize(raw))
 		},
+		"hasSuffix": strings.HasSuffix,
 	}
 
 	// Parse the base layout once as a clonable template
@@ -304,6 +305,9 @@ func (s *Server) setupRoutes() {
 		api.GET("/diagnostics/plex-items", s.handleDiagnosticsPlexItems)
 		api.POST("/downloads/redownload/:asin", s.handleRedownload)
 		api.POST("/diagnostics/redownload-all", s.handleDiagnosticsRedownloadAll)
+
+		// Per-book conversion between m4b and chapter-split mp3.
+		api.POST("/books/:id/convert", s.handleConvertBook)
 	}
 }
 
@@ -1420,9 +1424,9 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		}
 	}
 	if format := c.PostForm("output_format"); format != "" {
-		if setSetting("output_format", format) {
-			restartRequired = true
-		}
+		// Output format is applied at runtime; no restart required.
+		_ = setSetting("output_format", format)
+		s.downloads.SetOutputFormat(format)
 	}
 	if _, ok := c.GetPostForm("download_concurrency"); ok {
 		if setSetting("download_concurrency", strings.TrimSpace(c.PostForm("download_concurrency"))) {
@@ -2059,6 +2063,43 @@ func (s *Server) handleRedownload(c *gin.Context) {
 		"success": true,
 		"message": fmt.Sprintf("Book '%s' has been queued for redownload", book.Title),
 	})
+}
+
+// handleConvertBook converts an existing book between single-file m4b and
+// chapter-split mp3 layouts in place.
+func (s *Server) handleConvertBook(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var id int64
+	if _, err := fmt.Sscanf(c.Param("id"), "%d", &id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid book id"})
+		return
+	}
+
+	target := strings.TrimSpace(c.PostForm("format"))
+	if target == "" {
+		target = strings.TrimSpace(c.Query("format"))
+	}
+	if target == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing target format"})
+		return
+	}
+
+	if err := s.downloads.ConvertBook(ctx, id, target); err != nil {
+		webLog.Error().Err(err).Int64("book_id", id).Str("target", target).Msg("convert failed")
+		if c.GetHeader("HX-Request") == "true" {
+			c.HTML(http.StatusInternalServerError, "settings_saved.html", gin.H{"Message": "Convert failed: " + err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if c.GetHeader("HX-Request") == "true" {
+		c.HTML(http.StatusOK, "settings_saved.html", gin.H{"Message": fmt.Sprintf("Converted to %s", target)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "format": target})
 }
 
 // handleDiagnosticsRedownloadAll redownloads only the problem books shown on the diagnostics page.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1423,10 +1423,16 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 			restartRequired = true
 		}
 	}
-	if format := c.PostForm("output_format"); format != "" {
-		// Output format is applied at runtime; no restart required.
-		_ = setSetting("output_format", format)
-		s.downloads.SetOutputFormat(format)
+	if raw := c.PostForm("output_format"); raw != "" {
+		// Normalize and reject anything that isn't a supported format so we
+		// never persist a value the runtime will silently ignore.
+		format := strings.ToLower(strings.TrimSpace(raw))
+		if format != "m4b" && format != "mp3" {
+			webLog.Warn().Str("value", raw).Msg("ignoring invalid output_format")
+		} else {
+			_ = setSetting("output_format", format)
+			s.downloads.SetOutputFormat(format)
+		}
 	}
 	if _, ok := c.GetPostForm("download_concurrency"); ok {
 		if setSetting("download_concurrency", strings.TrimSpace(c.PostForm("download_concurrency"))) {
@@ -2070,8 +2076,8 @@ func (s *Server) handleRedownload(c *gin.Context) {
 func (s *Server) handleConvertBook(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var id int64
-	if _, err := fmt.Sscanf(c.Param("id"), "%d", &id); err != nil {
+	id, err := strconv.ParseInt(strings.TrimSpace(c.Param("id")), 10, 64)
+	if err != nil || id <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid book id"})
 		return
 	}
@@ -2086,12 +2092,16 @@ func (s *Server) handleConvertBook(c *gin.Context) {
 	}
 
 	if err := s.downloads.ConvertBook(ctx, id, target); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, library.ErrConvertInProgress) {
+			status = http.StatusConflict
+		}
 		webLog.Error().Err(err).Int64("book_id", id).Str("target", target).Msg("convert failed")
 		if c.GetHeader("HX-Request") == "true" {
-			c.HTML(http.StatusInternalServerError, "settings_saved.html", gin.H{"Message": "Convert failed: " + err.Error()})
+			c.HTML(status, "settings_saved.html", gin.H{"Message": "Convert failed: " + err.Error()})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(status, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1421,7 +1421,10 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		if strings.TrimSpace(current) == value {
 			return false
 		}
-		_ = s.db.SetSetting(ctx, key, value)
+		if err := s.db.SetSetting(ctx, key, value); err != nil {
+			webLog.Error().Err(err).Str("key", key).Msg("failed to persist setting")
+			return false
+		}
 		return true
 	}
 
@@ -1449,8 +1452,14 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		if format != "m4b" && format != "mp3" {
 			webLog.Warn().Str("value", raw).Msg("ignoring invalid output_format")
 		} else {
-			_ = setSetting("output_format", format)
-			s.downloads.SetOutputFormat(format)
+			current, _ := s.db.GetSetting(ctx, "output_format")
+			if strings.TrimSpace(current) == format {
+				s.downloads.SetOutputFormat(format)
+			} else if err := s.db.SetSetting(ctx, "output_format", format); err != nil {
+				webLog.Error().Err(err).Str("key", "output_format").Msg("failed to persist setting")
+			} else {
+				s.downloads.SetOutputFormat(format)
+			}
 		}
 	}
 	if _, ok := c.GetPostForm("download_concurrency"); ok {
@@ -1502,6 +1511,50 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		return
 	}
 	c.Redirect(http.StatusSeeOther, "/settings")
+}
+
+// removeBookPath deletes the stored book path regardless of whether it points
+// to a single file or a directory of chapter files. It also removes the parent
+// directory when it becomes empty (but never removes the library root).
+func (s *Server) removeBookPath(path string) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			webLog.Warn().Err(err).Str("path", path).Msg("failed to stat old book path")
+		}
+		return
+	}
+
+	if fi.IsDir() {
+		if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+			webLog.Warn().Err(err).Str("path", path).Msg("failed to remove old book directory")
+			return
+		}
+	} else {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			webLog.Warn().Err(err).Str("path", path).Msg("failed to remove old book file")
+			return
+		}
+	}
+
+	parentDir := filepath.Dir(filepath.Clean(path))
+	rootDir := filepath.Clean(s.audiobooksPath)
+	if parentDir == "" || parentDir == rootDir {
+		return
+	}
+	entries, err := os.ReadDir(parentDir)
+	if err == nil && len(entries) == 0 {
+		if err := os.Remove(parentDir); err != nil {
+			webLog.Warn().Err(err).Str("path", parentDir).Msg("failed to remove empty directory")
+		} else {
+			webLog.Info().Str("path", parentDir).Msg("removed empty directory")
+		}
+	}
 }
 
 // handleRestart requests process shutdown so the container/service can restart it.
@@ -2038,27 +2091,8 @@ func (s *Server) handleRedownload(c *gin.Context) {
 		return
 	}
 
-	// Delete the old file and folder if they exist
-	if book.FilePath != "" {
-		// First remove the file itself
-		if err := os.Remove(book.FilePath); err != nil && !os.IsNotExist(err) {
-			webLog.Warn().Err(err).Str("path", book.FilePath).Msg("failed to remove old file")
-		}
-
-		// Then check if the parent folder is empty and remove it
-		parentDir := filepath.Dir(book.FilePath)
-		if parentDir != "" && parentDir != s.audiobooksPath {
-			entries, err := os.ReadDir(parentDir)
-			if err == nil && len(entries) == 0 {
-				// Directory is empty, remove it
-				if err := os.Remove(parentDir); err != nil {
-					webLog.Warn().Err(err).Str("path", parentDir).Msg("failed to remove empty directory")
-				} else {
-					webLog.Info().Str("path", parentDir).Msg("removed empty book directory")
-				}
-			}
-		}
-	}
+	// Delete the old file or directory tree if it exists.
+	s.removeBookPath(book.FilePath)
 
 	// Reset book status to "new" so it can be re-downloaded
 	book.Status = database.BookStatusNew
@@ -2161,19 +2195,8 @@ func (s *Server) handleDiagnosticsRedownloadAll(c *gin.Context) {
 			continue
 		}
 
-		// Delete old file if it exists
-		if book.FilePath != "" {
-			if err := os.Remove(book.FilePath); err != nil && !os.IsNotExist(err) {
-				webLog.Warn().Err(err).Str("path", book.FilePath).Msg("failed to remove old file")
-			}
-			parentDir := filepath.Dir(book.FilePath)
-			if parentDir != "" && parentDir != s.audiobooksPath {
-				entries, err := os.ReadDir(parentDir)
-				if err == nil && len(entries) == 0 {
-					_ = os.Remove(parentDir)
-				}
-			}
-		}
+		// Delete old file or directory tree if it exists.
+		s.removeBookPath(book.FilePath)
 
 		// Reset book status
 		book.Status = database.BookStatusNew

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -38,11 +38,26 @@
         var maxReconnectDelay = 15000;
         var stageRateState = {};
 
+        // escHTML escapes a string for safe interpolation into innerHTML.
+        // ASINs, titles, and stage names come from upstream services; we
+        // never trust them in markup without escaping.
+        function escHTML(s) {
+            if (s == null) return '';
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         var badgeClass = {
             'downloading': 'badge-warning',
             'decrypting':  'badge-warning',
             'processing':  'badge-warning',
             'moving':      'badge-warning',
+            'converting':  'badge-warning',
+            'transcoding': 'badge-warning',
             'waiting_decrypt': 'badge-info',
             'waiting_moving':  'badge-info',
             'queued':      'badge-info',
@@ -55,6 +70,8 @@
             if (stage === 'moving') return 'moving file';
             if (stage === 'waiting_decrypt') return 'waiting for decrypt worker';
             if (stage === 'waiting_moving') return 'waiting for moving worker';
+            if (stage === 'converting') return 'converting';
+            if (stage === 'transcoding') return 'transcoding chapters';
             return stage || '';
         }
 
@@ -63,6 +80,8 @@
                 stage === 'decrypting' ||
                 stage === 'processing' ||
                 stage === 'moving' ||
+                stage === 'converting' ||
+                stage === 'transcoding' ||
                 stage === 'waiting_decrypt' ||
                 stage === 'waiting_moving';
         }
@@ -414,11 +433,25 @@
 
                     var bClass = badgeClass[stage] || 'badge-warning';
                     var isWaiting = (stage === 'waiting_decrypt' || stage === 'waiting_moving');
-                    card.innerHTML = '<div class="dl-info"><strong>' + label + '</strong>' +
-                        '<span class="badge ' + bClass + '">' + stageText +
+                    var cancellable = (stage === 'downloading' || stage === 'decrypting' || stage === 'processing' || stage === 'moving' || stage === 'converting' || stage === 'transcoding');
+
+                    // Once the user has clicked Cancel we mark the card so
+                    // subsequent SSE redraws don't restore the active button
+                    // (which would let them click it again before the server
+                    // catches up). The card sticks around until the failed/
+                    // complete event arrives.
+                    if (card && card.getAttribute('data-cancelling') === '1') {
+                        return;
+                    }
+
+                    var cancelBtn = cancellable
+                        ? '<button class="btn btn-small btn-danger pipe-cancel" data-asin="' + escHTML(d.asin) + '">Cancel</button>'
+                        : '';
+                    card.innerHTML = '<div class="dl-info"><strong>' + escHTML(label) + '</strong>' +
+                        '<span class="badge ' + bClass + '">' + escHTML(stageText) +
                         (!isWaiting && pct > 0 ? ' ' + pct + '%' : '') +
-                        '</span></div>' + details +
-                        ((stage === 'downloading' || stage === 'decrypting' || stage === 'processing' || stage === 'moving' || stage === 'waiting_decrypt' || stage === 'waiting_moving') ? '<div class="progress-bar"><div class="progress-fill" style="width:' + pct + '%"></div></div>' : '');
+                        '</span>' + cancelBtn + '</div>' + details +
+                        ((stage === 'downloading' || stage === 'decrypting' || stage === 'processing' || stage === 'moving' || stage === 'converting' || stage === 'transcoding' || stage === 'waiting_decrypt' || stage === 'waiting_moving') ? '<div class="progress-bar"><div class="progress-fill" style="width:' + pct + '%"></div></div>' : '');
                 } else if (d.type === 'complete') {
                     clearStageRateState(d.asin);
                     if (card) card.remove();
@@ -518,6 +551,23 @@
         window.addEventListener('beforeunload', function() {
             closeEventSource();
             clearReconnectTimer();
+        });
+
+        // Delegated handler for the Cancel button on active pipeline cards.
+        document.addEventListener('click', function(ev) {
+            var btn = ev.target.closest && ev.target.closest('.pipe-cancel');
+            if (!btn) return;
+            var asin = btn.getAttribute('data-asin');
+            if (!asin) return;
+            if (!confirm('Cancel this in-flight pipeline item?')) return;
+            btn.disabled = true;
+            btn.textContent = 'Cancelling…';
+            // Mark the card so the SSE redraw loop doesn't recreate a
+            // fresh active Cancel button on the next progress event.
+            var card = document.getElementById('pipe-' + asin);
+            if (card) card.setAttribute('data-cancelling', '1');
+            fetch('/api/downloads/cancel-active/' + encodeURIComponent(asin), { method: 'POST' })
+                .catch(function() { /* SSE will reflect the eventual failed state */ });
         });
 
         connectEventSource();

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -567,7 +567,14 @@
             var card = document.getElementById('pipe-' + asin);
             if (card) card.setAttribute('data-cancelling', '1');
             fetch('/api/downloads/cancel-active/' + encodeURIComponent(asin), { method: 'POST' })
-                .catch(function() { /* SSE will reflect the eventual failed state */ });
+                .catch(function() {
+                    // Request failed to reach the server (network error, etc.) so
+                    // the server never cancelled the item. Roll back the frozen state
+                    // so SSE progress events resume updating the card normally.
+                    if (card) card.removeAttribute('data-cancelling');
+                    btn.disabled = false;
+                    btn.textContent = 'Cancel';
+                });
         });
 
         connectEventSource();

--- a/internal/web/templates/book_detail_panel.html
+++ b/internal/web/templates/book_detail_panel.html
@@ -20,6 +20,19 @@
             {{if eq (printf "%s" .Book.Status) "new"}}
             <button hx-post="/api/downloads/queue/{{.Book.ASIN}}" hx-swap="none" class="btn btn-primary">Queue Download</button>
             {{end}}
+            {{if and (eq (printf "%s" .Book.Status) "complete") .Book.FilePath}}
+                {{if hasSuffix .Book.FilePath ".m4b"}}
+                <button hx-post="/api/books/{{.Book.ID}}/convert?format=mp3"
+                        hx-confirm="Split this book into per-chapter MP3 files? The original M4B will be removed."
+                        hx-swap="none"
+                        class="btn btn-secondary">Convert to MP3 (chapters)</button>
+                {{else}}
+                <button hx-post="/api/books/{{.Book.ID}}/convert?format=m4b"
+                        hx-confirm="Reassemble chapter MP3s into a single M4B? The chapter files will be removed."
+                        hx-swap="none"
+                        class="btn btn-secondary">Convert to M4B (single file)</button>
+                {{end}}
+            {{end}}
         </div>
 
         {{if .Book.Description}}


### PR DESCRIPTION
The "MP3 (Chapter Split)" option in Settings was a no-op.  The setting was persisted to the DB and stored on `DownloadManager` but never read by the processing pipeline, so every book was written as a single `.m4b` regardless of the user's choice. This PR finishes the wiring using the `SplitChapters` ffmpeg helper that already existed in `internal/audio`, and adds a convert action on the book detail page so existing libraries can be migrated either direction without a re-download.

## Changes

### Fix: MP3 chapter-split output format now works (`3662d05`)
- `DownloadManager`: add `SetOutputFormat` / `OutputFormat` (mutex-guarded) following the existing `SetEmbedCover` pattern, so the setting applies at runtime.
- `handleProcessStage`: when format is `mp3` and audnexus chapter data is available, run `SplitChapters` into a staging dir under `downloadDir` and hand it to a new `PlexOrganizer.OrganizeMultiFile` which moves per-chapter files into the canonical Plex book folder. Falls back to single-file `m4b` (with a warning log) when chapter data is missing.
- Settings handler: apply `output_format` via `SetOutputFormat` instead of marking the change `restartRequired`.
- `PlexOrganizer.OrganizeMultiFile`: new entry point for multi-file output. Reuses `buildFilenameBase` / `buildBookDirectoryName` / `sanitizePath`, writes the same `.plexmatch` and `.chapters.txt` companion files when those settings are on, and records the book directory as `FilePath` with cumulative `FileSize`.

### Feature: per-book convert action (`561d0a3`)
- `POST /api/books/:id/convert?format={m4b|mp3}` endpoint.
- `DownloadManager.ConvertBook` auto-detects current layout (file vs directory + extension), refreshes metadata via audnexus for chapter marks, and either splits the m4b into chapter mp3s or concatenates the chapter mp3s back into a single m4b. Staging goes through `downloadDir` so a failure leaves the existing layout untouched. Triggers a Plex scan on completion and updates the book record.
- `audio.FFmpeg.ConcatToM4B`: new helper using the ffmpeg concat demuxer + AAC re-encode.
- `hasSuffix` template func and a confirm-prompted button on `book_detail_panel.html` (visible only for completed books). Label flips based on current on-disk format.

## Notes / decisions

- **Runtime vs. restart-required:** `output_format` is now applied without a restart, matching how `embed_cover` / `chapter_file` already worked. This felt more consistent with the existing toggles.
- **Multi-file `FilePath`:** for the chapter-split layout the book's `FilePath` is set to the *directory* rather than a single file, and `FileSize` to the sum of chapter sizes. The existing redownload handler already tolerates this (it uses `filepath.Dir` and removes the parent if empty), but reviewers may want to check other consumers I didn't audit.
- **Convert metadata refresh:** I call `audnexus.EnrichMetadata` on every convert so chapter marks / canonical title are fresh, falling back to the DB row on failure. This matches the pattern used elsewhere in the pipeline.
