### PR TITLE
fix(diagnostics): fall back to path-based ASIN match for ABS items

### DIFF
--- a/internal/library/library_reconcile.go
+++ b/internal/library/library_reconcile.go
@@ -294,12 +294,50 @@ func findBestFileForBook(ctx context.Context, book *database.Book, libraryRoot s
 //
 // The Audible API sometimes returns ISBNs in place of ASINs, so we match all common formats.
 // Accepts Audible ASINs (BXXXXXXXXX), ISBN-10 (including trailing X checksum), and ISBN-13.
+//
+// Note: the Audible-ASIN alternative (B + 9 alphanumerics) is intentionally
+// permissive at the regex level because Go's RE2 engine has no lookaround.
+// The B-prefix branch can therefore over-match common English words such as
+// "Brightness" or "Bloodlines" (both 10-letter B-words). Real Audible ASINs
+// always contain at least one digit, so isLikelyRealASIN below filters those
+// pseudo-matches out before extractASINFromPath returns.
 var asinPathRe = regexp.MustCompile(`(?i)\b(?:B[0-9A-Z]{9}|97[89][0-9]{10}|[0-9]{9}[0-9X])\b`)
+
+// isLikelyRealASIN rejects regex hits that look like an Audible ASIN purely
+// because they're a 10-character B-prefixed word. Audible ASINs always carry
+// at least one digit; pure-alpha tokens are English words (BRIGHTNESS,
+// BLOODLINES, BOUNDARIES, ...) that the regex can't exclude on its own.
+// ISBN-10 / ISBN-13 alternatives are all digits, so they always pass.
+func isLikelyRealASIN(token string) bool {
+	upper := strings.ToUpper(token)
+	if strings.HasPrefix(upper, "B") {
+		for _, r := range upper {
+			if r >= '0' && r <= '9' {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
 
 // ExtractASINFromPath is an exported alias of extractASINFromPath so that
 // other packages (e.g. internal/web diagnostics) can reuse the same path-token
 // parsing rules without duplicating the regex.
 func ExtractASINFromPath(path string) string { return extractASINFromPath(path) }
+
+// firstRealASIN scans every regex hit in a single path segment and returns
+// the first one that survives the digit filter. We use FindAllString rather
+// than FindString so that a B-prefixed English word at the start of a
+// folder name doesn't shadow a real identifier later in the same segment.
+func firstRealASIN(segment string) string {
+	for _, m := range asinPathRe.FindAllString(segment, -1) {
+		if isLikelyRealASIN(m) {
+			return strings.ToUpper(m)
+		}
+	}
+	return ""
+}
 
 // extractASINFromPath searches for an Audible ASIN (or ISBN-10 fallback) anywhere in a file path.
 // Audible ASINs start with 'B' + 9 alphanumerics, but the Audible API sometimes returns ISBN-10s
@@ -307,14 +345,14 @@ func ExtractASINFromPath(path string) string { return extractASINFromPath(path) 
 // we match both patterns. The filename is checked first (most specific), then parent directories.
 func extractASINFromPath(path string) string {
 	// Check filename first
-	if match := asinPathRe.FindString(filepath.Base(path)); match != "" {
-		return strings.ToUpper(match)
+	if match := firstRealASIN(filepath.Base(path)); match != "" {
+		return match
 	}
 	// Walk up directory components
 	dir := filepath.Dir(path)
 	for {
-		if match := asinPathRe.FindString(filepath.Base(dir)); match != "" {
-			return strings.ToUpper(match)
+		if match := firstRealASIN(filepath.Base(dir)); match != "" {
+			return match
 		}
 		next := filepath.Dir(dir)
 		if next == dir { // reached filesystem root

--- a/internal/library/library_reconcile.go
+++ b/internal/library/library_reconcile.go
@@ -296,6 +296,11 @@ func findBestFileForBook(ctx context.Context, book *database.Book, libraryRoot s
 // Accepts Audible ASINs (BXXXXXXXXX), ISBN-10 (including trailing X checksum), and ISBN-13.
 var asinPathRe = regexp.MustCompile(`(?i)\b(?:B[0-9A-Z]{9}|97[89][0-9]{10}|[0-9]{9}[0-9X])\b`)
 
+// ExtractASINFromPath is an exported alias of extractASINFromPath so that
+// other packages (e.g. internal/web diagnostics) can reuse the same path-token
+// parsing rules without duplicating the regex.
+func ExtractASINFromPath(path string) string { return extractASINFromPath(path) }
+
 // extractASINFromPath searches for an Audible ASIN (or ISBN-10 fallback) anywhere in a file path.
 // Audible ASINs start with 'B' + 9 alphanumerics, but the Audible API sometimes returns ISBN-10s
 // (10 digits) in place of ASINs. Since the organizer writes whatever identifier came from the API,

--- a/internal/library/library_reconcile_test.go
+++ b/internal/library/library_reconcile_test.go
@@ -126,6 +126,57 @@ func TestExtractASINFromPathMatchesISBN10WithX(t *testing.T) {
 	}
 }
 
+// TestExtractASINFromPathIgnoresBWordFalsePositives guards the digit filter in
+// isLikelyRealASIN. The regex alternative for Audible ASINs is "B" followed by
+// 9 alphanumeric characters; without a digit-presence check it will happily
+// match English words like BRIGHTNESS or BLOODLINES (both 10 letters starting
+// with B). Real Audible ASINs always contain at least one digit, so the
+// extractor should skip pseudo-matches and keep walking. Here the real
+// identifier is the ISBN-10 1501966235 in the same folder name — we expect
+// that to win, not the leading word "Brightness".
+func TestExtractASINFromPathIgnoresBWordFalsePositives(t *testing.T) {
+	path := filepath.Join("root", "Guy Gavriel Kay", "A Brightness Long Ago 1501966235 [us]", "A Brightness Long Ago 1501966235 [us].m4b")
+	got := extractASINFromPath(path)
+	if got != "1501966235" {
+		t.Fatalf("extractASINFromPath() = %q, want %q (must skip the B-word 'Brightness')", got, "1501966235")
+	}
+}
+
+// TestExtractASINFromPathReturnsEmptyWhenOnlyBWordPresent covers the case
+// where a folder name contains a B-prefixed English word but no real ASIN /
+// ISBN at all. Earlier behavior would wrongly return the uppercased word; new
+// behavior should return "" so the caller can take its own missing-ASIN path.
+func TestExtractASINFromPathReturnsEmptyWhenOnlyBWordPresent(t *testing.T) {
+	path := filepath.Join("root", "Some Author", "Bloodlines [us]", "Bloodlines.m4b")
+	got := extractASINFromPath(path)
+	if got != "" {
+		t.Fatalf("extractASINFromPath() = %q, want \"\" (no real ASIN, just the word 'Bloodlines')", got)
+	}
+}
+
+// TestIsLikelyRealASIN exercises the digit-presence helper directly so the
+// filter stays correct even if extractASINFromPath grows new call sites.
+func TestIsLikelyRealASIN(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"B088C4DBYP", true},  // real Audible ASIN
+		{"B0DCCZ5MG2", true},  // real Audible ASIN
+		{"BRIGHTNESS", false}, // English word, no digits
+		{"BLOODLINES", false}, // English word, no digits
+		{"BOUNDARIES", false}, // another B-word for good measure
+		{"1501966235", true},  // ISBN-10
+		{"103940474X", true},  // ISBN-10 with X checksum
+		{"9780143127550", true}, // ISBN-13
+	}
+	for _, c := range cases {
+		if got := isLikelyRealASIN(c.in); got != c.want {
+			t.Errorf("isLikelyRealASIN(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
 func TestBuildASINIndexExtractsISBN10FromFolder(t *testing.T) {
 	// ISBN-10 in folder name should be indexed like any ASIN.
 	isbnPath := filepath.Join("root", "Author", "Book Title 0593393864 [us]", "Book Title.m4b")

--- a/internal/web/diagnostics_handlers.go
+++ b/internal/web/diagnostics_handlers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mstrhakr/audplexus/internal/database"
+	"github.com/mstrhakr/audplexus/internal/library"
 	"github.com/mstrhakr/audplexus/internal/mediaserver"
 )
 
@@ -422,6 +423,24 @@ func (s *Server) matchBookAgainstInventory(book database.Book, onDisk bool, inv 
 		if len(match) > 1 {
 			return false, "", "unknown: multiple ABS items share ASIN", empty
 		}
+
+		// metadata.asin missed. ABS may have auto-matched the book to a different
+		// edition during library scan, leaving metadata.asin pointing at an
+		// alternate ISBN/ASIN even though the book folder itself was named after
+		// the Audible ASIN by the organizer. Fall back to the folder/file path
+		// token, which is the source of truth Audplexus controls.
+		pathMatches := make([]diagnosticsRemoteItem, 0, 1)
+		for _, it := range inv.Items {
+			if remoteASIN := library.ExtractASINFromPath(it.Path); remoteASIN != "" && strings.EqualFold(remoteASIN, asin) {
+				pathMatches = append(pathMatches, it)
+			}
+		}
+		if len(pathMatches) == 1 {
+			return true, "asin_path", "", pathMatches[0]
+		}
+		if len(pathMatches) > 1 {
+			return false, "", "unknown: multiple ABS items share ASIN in path", empty
+		}
 		return false, "", "missing: ASIN not found in destination", empty
 	}
 
@@ -528,9 +547,11 @@ func fetchABSDiagnosticsItems(ctx context.Context, d database.LibraryDestination
 		}
 		var parsed struct {
 			Results []struct {
-				ID    string `json:"id"`
-				Title string `json:"title"`
-				Media struct {
+				ID      string `json:"id"`
+				Title   string `json:"title"`
+				Path    string `json:"path"`
+				RelPath string `json:"relPath"`
+				Media   struct {
 					Metadata struct {
 						ASIN string `json:"asin"`
 					} `json:"metadata"`
@@ -546,7 +567,16 @@ func fetchABSDiagnosticsItems(ctx context.Context, d database.LibraryDestination
 			break
 		}
 		for _, r := range parsed.Results {
-			items = append(items, diagnosticsRemoteItem{ID: r.ID, Title: r.Title, ASIN: strings.ToUpper(strings.TrimSpace(r.Media.Metadata.ASIN))})
+			path := strings.TrimSpace(r.Path)
+			if path == "" {
+				path = strings.TrimSpace(r.RelPath)
+			}
+			items = append(items, diagnosticsRemoteItem{
+				ID:    r.ID,
+				Title: r.Title,
+				Path:  path,
+				ASIN:  strings.ToUpper(strings.TrimSpace(r.Media.Metadata.ASIN)),
+			})
 		}
 		if len(parsed.Results) < 200 {
 			break

--- a/internal/web/diagnostics_handlers_test.go
+++ b/internal/web/diagnostics_handlers_test.go
@@ -45,3 +45,92 @@ func TestMatchBookAgainstInventoryPlexUsesPathSuffix(t *testing.T) {
 		t.Fatalf("matchBookAgainstInventory() remote.ID = %q, want %q", remote.ID, "211150")
 	}
 }
+
+// TestMatchBookAgainstInventoryABSExactASIN covers the happy path: ABS items
+// whose metadata.asin field exactly matches the local book's ASIN.
+func TestMatchBookAgainstInventoryABSExactASIN(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	book := database.Book{ID: 1, ASIN: "B088C4DBYP", Title: "Heaven's River"}
+	inv := diagnosticsDestinationInventory{
+		Destination: database.LibraryDestination{Type: database.LibraryDestinationTypeABS},
+		Items: []diagnosticsRemoteItem{{
+			ID:    "abs-1",
+			Title: "Heaven's River",
+			Path:  "/audiobooks/Dennis E. Taylor/Heaven's River B088C4DBYP [us]",
+			ASIN:  "B088C4DBYP",
+		}},
+	}
+
+	matched, method, reason, remote := server.matchBookAgainstInventory(book, true, inv)
+	if !matched {
+		t.Fatalf("matchBookAgainstInventory() matched = false, reason = %q", reason)
+	}
+	if method != "asin_exact" {
+		t.Fatalf("matchBookAgainstInventory() method = %q, want %q", method, "asin_exact")
+	}
+	if remote.ID != "abs-1" {
+		t.Fatalf("matchBookAgainstInventory() remote.ID = %q, want %q", remote.ID, "abs-1")
+	}
+}
+
+// TestMatchBookAgainstInventoryABSPathFallback covers the edition-mismatch case:
+// ABS auto-matched the book to a different edition during library scan, so
+// metadata.asin points at a different ISBN/ASIN. The book folder, however, was
+// named by the Audplexus organizer with the correct identifier, so we should
+// fall back to parsing the ASIN out of the destination item's path.
+func TestMatchBookAgainstInventoryABSPathFallback(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	book := database.Book{ID: 1, ASIN: "1524779261", Title: "Atomic Habits"}
+	inv := diagnosticsDestinationInventory{
+		Destination: database.LibraryDestination{Type: database.LibraryDestinationTypeABS},
+		Items: []diagnosticsRemoteItem{{
+			ID:    "abs-42",
+			Title: "Atomic Habits",
+			Path:  "/audiobooks/James Clear/Atomic Habits 1524779261 [us]",
+			// ABS picked up an alternate UK edition during its scan.
+			ASIN: "1473565421",
+		}},
+	}
+
+	matched, method, reason, remote := server.matchBookAgainstInventory(book, true, inv)
+	if !matched {
+		t.Fatalf("matchBookAgainstInventory() matched = false, reason = %q", reason)
+	}
+	if method != "asin_path" {
+		t.Fatalf("matchBookAgainstInventory() method = %q, want %q", method, "asin_path")
+	}
+	if remote.ID != "abs-42" {
+		t.Fatalf("matchBookAgainstInventory() remote.ID = %q, want %q", remote.ID, "abs-42")
+	}
+}
+
+// TestMatchBookAgainstInventoryABSMissingWhenPathAlsoDoesNotMatch ensures we
+// still report "missing" when neither metadata.asin nor any item path contains
+// the local ASIN. This guards against the path fallback being too greedy.
+func TestMatchBookAgainstInventoryABSMissingWhenPathAlsoDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	book := database.Book{ID: 1, ASIN: "B0FAKE0001", Title: "Not In Library"}
+	inv := diagnosticsDestinationInventory{
+		Destination: database.LibraryDestination{Type: database.LibraryDestinationTypeABS},
+		Items: []diagnosticsRemoteItem{{
+			ID:    "abs-99",
+			Title: "Some Other Book",
+			Path:  "/audiobooks/Someone Else/Some Other Book B099OTHER1 [us]",
+			ASIN:  "B099OTHER1",
+		}},
+	}
+
+	matched, _, reason, _ := server.matchBookAgainstInventory(book, true, inv)
+	if matched {
+		t.Fatalf("matchBookAgainstInventory() matched = true, want false")
+	}
+	if reason != "missing: ASIN not found in destination" {
+		t.Fatalf("matchBookAgainstInventory() reason = %q, want missing", reason)
+	}
+}


### PR DESCRIPTION
## What

In the per-destination diagnostics page, ABS books are reported as `missing: ASIN not found in destination` even when they are present in the ABS library. On a 341-book library I'm seeing 100 / 341 false negatives.

This PR adds a path-based ASIN fallback to the ABS matcher in `internal/web/diagnostics_handlers.go` so that books whose ABS `metadata.asin` was rewritten by ABS's own scanner are still correctly identified.

## Why

`fetchABSDiagnosticsItems` pulls each library item and stores `media.metadata.asin`. `matchBookAgainstInventory` then matches the local book by that single field. The problem is that `media.metadata.asin` is the value ABS's library scanner picked from its configured metadata providers — and for a non-trivial number of books, that scanner happily auto-matches the folder to a different edition (US Audible -> UK paperback ISBN, alternate audiobook reissue, etc.). The folder name itself, written by the Audplexus organizer, still carries the correct identifier, but the matcher never looks at it.

Sample of what I was seeing locally — same row in both sides, just different ASINs:

| Title           | Local (organizer) ASIN | ABS `metadata.asin` | ABS path                                    |
| --------------- | ---------------------- | ------------------- | ------------------------------------------- |
| Atomic Habits   | `1524779261`           | `1473565421`        | `…/Atomic Habits 1524779261 [us]`           |
| Born a Crime    | `B01IW9TQPK`           | `B01M6W3BEW`        | `…/Born a Crime B01IW9TQPK [us]`            |
| Old Man's War   | `B002V1O7D2`           | `B0DSQ3WM2D`        | `…/Old Man's War B002V1O7D2 [us]`           |
| The Hobbit      | `1705009050`           | `0008433844`        | `…/The Hobbit 1705009050 [us]`              |

In every one of these cases the book is in ABS, the folder name is correct, and ABS's own scanner just happened to pick a different edition's metadata. Today the diagnostics page calls them missing and offers a Redownload (Last Resort) button, which would be quite destructive for a book that is already on disk and indexed.

## How

1. `internal/library/library_reconcile.go`: add a thin `ExtractASINFromPath` wrapper so other packages can reuse the existing organizer regex without duplicating it.
2. `internal/web/diagnostics_handlers.go`:
   - `fetchABSDiagnosticsItems` now also captures `path` / `relPath` from each ABS item (previously discarded) and populates `diagnosticsRemoteItem.Path` (the field already existed for Plex/Emby/Jellyfin).
   - `matchBookAgainstInventory` ABS branch: after the existing `metadata.asin` lookup misses, do a second pass over the inventory and check each item's path for the local ASIN token. On a single hit, return `method = "asin_path"`. On multiple, return `unknown: multiple ABS items share ASIN in path`. Otherwise return the original `missing` reason — behavior is unchanged for books that genuinely are not present.

The new `asin_path` method gives the existing diagnostics log lines a way to surface that the fallback was used, which should help when debugging future ABS metadata oddities.

## Tests

`go test ./...` is green. New cases in `internal/web/diagnostics_handlers_test.go`:

- `TestMatchBookAgainstInventoryABSExactASIN` — pins the existing happy path so a future refactor can't silently change it.
- `TestMatchBookAgainstInventoryABSPathFallback` — covers the edition-mismatch case (the actual bug).
- `TestMatchBookAgainstInventoryABSMissingWhenPathAlsoDoesNotMatch` — guards against the fallback being too lenient; a book whose ASIN does not appear in any inventory path is still reported as missing.

## Not in scope

- Cleaning up the ABS `metadata.asin` values themselves so they line up with the on-disk identifier. That feels like a separate, optional follow-up — possibly an opt-in "push organizer metadata to ABS" step. Happy to look at it in a future PR if it sounds useful.
- Plex / Emby / Jellyfin branches. I didn't see the same failure mode there because those backends already match by path/filename rather than by a metadata-provider-sourced identifier.

Thanks for taking a look!