### PR TITLE
UI Pass 2 and sync/process improvements

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -103,6 +103,11 @@ func main() {
 	syncSvc := library.NewSyncService(db, audibleClient, cfg.Paths.Audiobooks)
 	anClient := audnexus.NewClientWithRegion(region)
 	log.Info().Str("region", region).Msg("audnexus client initialized with region")
+	// Wire optional dependencies for the Metadata Repair sync phase.
+	// Both are tolerated as nil at the SyncService boundary so tests
+	// and lightweight uses don't have to construct them.
+	syncSvc.SetFFmpeg(ffmpeg)
+	syncSvc.SetAudnexusClient(anClient)
 	org := organizer.NewPlexOrganizer(db, ffmpeg, cfg.Paths.Audiobooks, cfg.Output.EmbedCover, cfg.Output.ChapterFile, cfg.Output.PlexMatchFile)
 
 	// First-boot synthesis: if library_destinations is empty AND legacy

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -175,7 +175,7 @@ func main() {
 	log.Info().Bool("enabled", cfg.Sync.Enabled).Str("schedule", cfg.Sync.Schedule).Msg("scheduler started")
 
 	// Start web server
-	webServer := web.NewServer(db, syncSvc, dlMgr, anClient, org, audibleClient, credPath, cfg.Server.Port, cfg.Paths.Audiobooks, cfg.Paths.Downloads, cfg.Paths.Config)
+	webServer := web.NewServer(db, syncSvc, dlMgr, anClient, org, audibleClient, ffmpeg, credPath, cfg.Server.Port, cfg.Paths.Audiobooks, cfg.Paths.Downloads, cfg.Paths.Config)
 	go func() {
 		if err := webServer.Start(); err != nil {
 			log.Fatal().Err(err).Msg("web server failed")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -175,7 +175,7 @@ func main() {
 	log.Info().Bool("enabled", cfg.Sync.Enabled).Str("schedule", cfg.Sync.Schedule).Msg("scheduler started")
 
 	// Start web server
-	webServer := web.NewServer(db, syncSvc, dlMgr, anClient, org, audibleClient, ffmpeg, credPath, cfg.Server.Port, cfg.Paths.Audiobooks, cfg.Paths.Downloads, cfg.Paths.Config)
+	webServer := web.NewServer(db, syncSvc, dlMgr, sched, anClient, org, audibleClient, ffmpeg, credPath, cfg.Server.Port, cfg.Paths.Audiobooks, cfg.Paths.Downloads, cfg.Paths.Config)
 	go func() {
 		if err := webServer.Start(); err != nil {
 			log.Fatal().Err(err).Msg("web server failed")

--- a/internal/audio/probe_tags.go
+++ b/internal/audio/probe_tags.go
@@ -1,0 +1,37 @@
+package audio
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// ProbeTags returns the format-level metadata tags from an audio file.
+// Reads via ffprobe; the freeform iTunes atoms emitted by the
+// AudiobookRich profile (asin, series, series-part) come back as plain
+// string keys.
+func (f *FFmpeg) ProbeTags(ctx context.Context, inputPath string) (map[string]string, error) {
+	cmd := exec.CommandContext(ctx, f.probePath,
+		"-v", "quiet",
+		"-show_entries", "format_tags",
+		"-of", "json",
+		inputPath,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe tags: %w", err)
+	}
+	var resp struct {
+		Format struct {
+			Tags map[string]string `json:"tags"`
+		} `json:"format"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("decode ffprobe tags: %w", err)
+	}
+	if resp.Format.Tags == nil {
+		return map[string]string{}, nil
+	}
+	return resp.Format.Tags, nil
+}

--- a/internal/audio/probe_tags.go
+++ b/internal/audio/probe_tags.go
@@ -35,3 +35,112 @@ func (f *FFmpeg) ProbeTags(ctx context.Context, inputPath string) (map[string]st
 	}
 	return resp.Format.Tags, nil
 }
+
+// FileProbe is the rich-probe snapshot used by the Book Details "File
+// info" block: format, codec, container/stream technicals, chapter
+// count, embedded artwork flag, and the raw tag map. Numeric fields
+// stay as their ffprobe-reported strings so the UI can render "—"
+// for absent values without a separate "set" flag per field.
+type FileProbe struct {
+	FormatName      string            `json:"format_name"`
+	FormatLongName  string            `json:"format_long_name"`
+	DurationSec     float64           `json:"duration_sec"`
+	BitRate         string            `json:"bit_rate"`
+	Size            int64             `json:"size"`
+	NumStreams      int               `json:"num_streams"`
+	AudioCodec      string            `json:"audio_codec"`
+	AudioCodecLong  string            `json:"audio_codec_long"`
+	AudioBitRate    string            `json:"audio_bit_rate"`
+	SampleRate      string            `json:"sample_rate"`
+	Channels        int               `json:"channels"`
+	ChannelLayout   string            `json:"channel_layout"`
+	HasArtwork      bool              `json:"has_artwork"`
+	ChapterCount    int               `json:"chapter_count"`
+	Tags            map[string]string `json:"tags"`
+}
+
+// ProbeFile returns a FileProbe with everything the Book Details "File
+// info" block surfaces: container/codec technicals, chapter count,
+// embedded artwork flag, plus the raw format-level tags. One ffprobe
+// invocation that asks for format+streams+chapters in JSON.
+func (f *FFmpeg) ProbeFile(ctx context.Context, inputPath string) (*FileProbe, error) {
+	cmd := exec.CommandContext(ctx, f.probePath,
+		"-v", "quiet",
+		"-show_format",
+		"-show_streams",
+		"-show_chapters",
+		"-of", "json",
+		inputPath,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ffprobe file: %w", err)
+	}
+
+	var resp struct {
+		Format struct {
+			FormatName     string            `json:"format_name"`
+			FormatLongName string            `json:"format_long_name"`
+			Duration       string            `json:"duration"`
+			Size           string            `json:"size"`
+			BitRate        string            `json:"bit_rate"`
+			NumStreams     int               `json:"nb_streams"`
+			Tags           map[string]string `json:"tags"`
+		} `json:"format"`
+		Streams []struct {
+			CodecType      string `json:"codec_type"`
+			CodecName      string `json:"codec_name"`
+			CodecLongName  string `json:"codec_long_name"`
+			BitRate        string `json:"bit_rate"`
+			SampleRate     string `json:"sample_rate"`
+			Channels       int    `json:"channels"`
+			ChannelLayout  string `json:"channel_layout"`
+			Disposition    map[string]int `json:"disposition"`
+		} `json:"streams"`
+		Chapters []struct {
+			ID int `json:"id"`
+		} `json:"chapters"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("decode ffprobe file: %w", err)
+	}
+
+	probe := &FileProbe{
+		FormatName:     resp.Format.FormatName,
+		FormatLongName: resp.Format.FormatLongName,
+		BitRate:        resp.Format.BitRate,
+		NumStreams:     resp.Format.NumStreams,
+		ChapterCount:   len(resp.Chapters),
+		Tags:           resp.Format.Tags,
+	}
+	if probe.Tags == nil {
+		probe.Tags = map[string]string{}
+	}
+	if resp.Format.Duration != "" {
+		fmt.Sscanf(resp.Format.Duration, "%f", &probe.DurationSec)
+	}
+	if resp.Format.Size != "" {
+		fmt.Sscanf(resp.Format.Size, "%d", &probe.Size)
+	}
+	for _, st := range resp.Streams {
+		switch st.CodecType {
+		case "audio":
+			if probe.AudioCodec == "" {
+				probe.AudioCodec = st.CodecName
+				probe.AudioCodecLong = st.CodecLongName
+				probe.AudioBitRate = st.BitRate
+				probe.SampleRate = st.SampleRate
+				probe.Channels = st.Channels
+				probe.ChannelLayout = st.ChannelLayout
+			}
+		case "video":
+			// A video stream on an audiobook means embedded cover
+			// art. The attached_pic disposition makes that explicit.
+			if st.Disposition["attached_pic"] == 1 || !probe.HasArtwork {
+				probe.HasArtwork = true
+			}
+		}
+	}
+	return probe, nil
+}
+

--- a/internal/audio/tag_profile.go
+++ b/internal/audio/tag_profile.go
@@ -6,8 +6,9 @@ import (
 )
 
 // TagProfile selects which set of metadata atoms get embedded into the m4b
-// when EmbedMetadata runs. Existing libraries upgrade transparently to the
-// Basic profile (today's behavior). Audiobook-rich is opt-in.
+// when EmbedMetadata runs. New installs default to Audiobook-rich so series
+// grouping works out of the box; Basic stays available for anyone who wants
+// the historical tag set.
 type TagProfile string
 
 const (
@@ -32,6 +33,11 @@ const (
 	TagProfileAudiobookRich TagProfile = "audiobook-rich"
 )
 
+// DefaultTagProfile is the profile used when nothing is stored yet (new
+// installs) or when a stored value can't be recognized. Audiobook-rich is
+// additive and safe — it only adds series/asin atoms on top of Basic.
+const DefaultTagProfile = TagProfileAudiobookRich
+
 // SettingKeyTagProfile is the DB setting key that stores the active tag
 // profile. Stored alongside other Audplexus settings.
 const SettingKeyTagProfile = "tag_profile"
@@ -45,19 +51,19 @@ type settingsReader interface {
 }
 
 // ResolveTagProfile reads the active tag profile from the DB setting,
-// falling back to Basic for any unset or unknown value. Existing installs
-// keep today's behavior automatically.
+// falling back to DefaultTagProfile for any unset or unknown value.
 func ResolveTagProfile(ctx context.Context, db settingsReader) TagProfile {
 	if db == nil {
-		return TagProfileBasic
+		return DefaultTagProfile
 	}
 	raw, _ := db.GetSetting(ctx, SettingKeyTagProfile)
 	return ParseTagProfile(raw)
 }
 
 // ParseTagProfile maps a setting string to a TagProfile, defaulting to
-// Basic for empty or unrecognized values. Lenient — used when reading
-// existing settings where unknown legacy values should fall back gracefully.
+// DefaultTagProfile for empty or unrecognized values. Lenient — used when
+// reading existing settings where unknown legacy values should fall back
+// gracefully.
 func ParseTagProfile(s string) TagProfile {
 	p, _ := parseTagProfile(s)
 	return p
@@ -73,12 +79,14 @@ func ParseTagProfileStrict(s string) (TagProfile, bool) {
 
 func parseTagProfile(s string) (TagProfile, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", string(TagProfileBasic):
+	case "":
+		return DefaultTagProfile, true
+	case string(TagProfileBasic):
 		return TagProfileBasic, true
 	case string(TagProfileAudiobookRich), "audiobook_rich", "rich":
 		return TagProfileAudiobookRich, true
 	default:
-		return TagProfileBasic, false
+		return DefaultTagProfile, false
 	}
 }
 

--- a/internal/audio/tag_profile_test.go
+++ b/internal/audio/tag_profile_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 )
 
-func TestParseTagProfileDefaultsToBasic(t *testing.T) {
+func TestParseTagProfileDefaults(t *testing.T) {
 	cases := map[string]TagProfile{
-		"":                  TagProfileBasic,
-		"basic":             TagProfileBasic,
-		"BASIC":             TagProfileBasic,
-		"audiobook-rich":    TagProfileAudiobookRich,
-		"AUDIOBOOK-RICH":    TagProfileAudiobookRich,
-		" audiobook-rich ":  TagProfileAudiobookRich,
-		"audiobook_rich":    TagProfileAudiobookRich,
-		"rich":              TagProfileAudiobookRich,
-		"unknown":           TagProfileBasic, // anything unrecognized falls back
-		"plex":              TagProfileBasic, // doesn't accidentally match a media-server type
+		"":                 DefaultTagProfile,
+		"basic":            TagProfileBasic,
+		"BASIC":            TagProfileBasic,
+		"audiobook-rich":   TagProfileAudiobookRich,
+		"AUDIOBOOK-RICH":   TagProfileAudiobookRich,
+		" audiobook-rich ": TagProfileAudiobookRich,
+		"audiobook_rich":   TagProfileAudiobookRich,
+		"rich":             TagProfileAudiobookRich,
+		"unknown":          DefaultTagProfile, // anything unrecognized falls back to default
+		"plex":             DefaultTagProfile, // doesn't accidentally match a media-server type
 	}
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {
@@ -28,9 +28,9 @@ func TestParseTagProfileDefaultsToBasic(t *testing.T) {
 }
 
 func TestResolveTagProfileNilDB(t *testing.T) {
-	// A nil DB must not panic; falls back to Basic.
-	if got := ResolveTagProfile(context.Background(), nil); got != TagProfileBasic {
-		t.Errorf("ResolveTagProfile(nil db) = %q, want %q", got, TagProfileBasic)
+	// A nil DB must not panic; falls back to the default profile.
+	if got := ResolveTagProfile(context.Background(), nil); got != DefaultTagProfile {
+		t.Errorf("ResolveTagProfile(nil db) = %q, want %q", got, DefaultTagProfile)
 	}
 }
 
@@ -52,10 +52,10 @@ func TestResolveTagProfileFromDB(t *testing.T) {
 		stored string
 		want   TagProfile
 	}{
-		{"", TagProfileBasic},                      // unset = default Basic
-		{"basic", TagProfileBasic},                 // explicit basic
-		{"audiobook-rich", TagProfileAudiobookRich}, // opt-in
-		{"junk", TagProfileBasic},                  // unknown stored value falls back
+		{"", DefaultTagProfile},                     // unset = default profile
+		{"basic", TagProfileBasic},                  // explicit basic
+		{"audiobook-rich", TagProfileAudiobookRich}, // explicit rich
+		{"junk", DefaultTagProfile},                 // unknown stored value falls back to default
 	} {
 		t.Run(tc.stored, func(t *testing.T) {
 			db := &fakeSettingsReader{value: tc.stored}
@@ -72,7 +72,7 @@ func TestAllTagProfilesIncludesBothInOrder(t *testing.T) {
 		t.Fatalf("AllTagProfiles() = %d entries, want 2", len(all))
 	}
 	if all[0] != TagProfileBasic {
-		t.Errorf("AllTagProfiles()[0] = %q, want Basic first (default)", all[0])
+		t.Errorf("AllTagProfiles()[0] = %q, want Basic first", all[0])
 	}
 	if all[1] != TagProfileAudiobookRich {
 		t.Errorf("AllTagProfiles()[1] = %q, want AudiobookRich second", all[1])

--- a/internal/database/books_presence_filter_test.go
+++ b/internal/database/books_presence_filter_test.go
@@ -1,0 +1,112 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestListBooksPresenceFilters covers the presence-filter slices on
+// BookFilter (OnDisk + PresentIn/MissingFrom destinations). Verifies
+// the WHERE-clause builder constructs subqueries that intersect with
+// book_library_destinations correctly.
+func TestListBooksPresenceFilters(t *testing.T) {
+	db := newTestSQLite(t)
+	ctx := context.Background()
+
+	// Two destinations: Plex + ABS.
+	plex := &LibraryDestination{
+		ID: uuid.NewString(), DisplayName: "Plex",
+		Type: LibraryDestinationTypePlex, Enabled: true,
+		URL: "http://plex.lan", PlexToken: "tok", PlexSectionID: "1",
+		AudiobookPath: "/m",
+	}
+	abs := &LibraryDestination{
+		ID: uuid.NewString(), DisplayName: "ABS",
+		Type: LibraryDestinationTypeABS, Enabled: true,
+		URL: "http://abs.lan", APIKey: "k", LibraryID: "lib",
+		AudiobookPath: "/m",
+	}
+	if err := db.CreateLibraryDestination(ctx, plex); err != nil {
+		t.Fatalf("create plex: %v", err)
+	}
+	if err := db.CreateLibraryDestination(ctx, abs); err != nil {
+		t.Fatalf("create abs: %v", err)
+	}
+
+	// Three books:
+	//   A: on disk, synced to plex, synced to abs
+	//   B: on disk, synced to plex only
+	//   C: not on disk, no destination sync rows
+	books := []*Book{
+		{ASIN: "B0001", Title: "A", Author: "x", Status: BookStatusComplete, FilePath: "/m/a.m4b"},
+		{ASIN: "B0002", Title: "B", Author: "x", Status: BookStatusComplete, FilePath: "/m/b.m4b"},
+		{ASIN: "B0003", Title: "C", Author: "x", Status: BookStatusNew, FilePath: ""},
+	}
+	for _, b := range books {
+		if err := db.UpsertBook(ctx, b); err != nil {
+			t.Fatalf("upsert %s: %v", b.ASIN, err)
+		}
+	}
+	bookA, _ := db.GetBookByASIN(ctx, "B0001")
+	bookB, _ := db.GetBookByASIN(ctx, "B0002")
+	for _, bd := range []*BookDestination{
+		{BookID: bookA.ID, DestinationID: plex.ID, SyncState: BookDestSyncSynced},
+		{BookID: bookA.ID, DestinationID: abs.ID, SyncState: BookDestSyncSynced},
+		{BookID: bookB.ID, DestinationID: plex.ID, SyncState: BookDestSyncSynced},
+	} {
+		if err := db.UpsertBookDestination(ctx, bd); err != nil {
+			t.Fatalf("upsert book-dest: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		filter   BookFilter
+		wantASIN []string
+	}{
+		{"on disk only", BookFilter{OnDisk: ptrBool(true)}, []string{"B0001", "B0002"}},
+		{"not on disk", BookFilter{OnDisk: ptrBool(false)}, []string{"B0003"}},
+		{"present in plex", BookFilter{PresentInDestinations: []string{plex.ID}}, []string{"B0001", "B0002"}},
+		{"present in abs", BookFilter{PresentInDestinations: []string{abs.ID}}, []string{"B0001"}},
+		{"missing from abs", BookFilter{MissingFromDestinations: []string{abs.ID}}, []string{"B0002", "B0003"}},
+		{"in plex AND missing from abs", BookFilter{PresentInDestinations: []string{plex.ID}, MissingFromDestinations: []string{abs.ID}}, []string{"B0002"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _, err := db.ListBooks(ctx, tc.filter)
+			if err != nil {
+				t.Fatalf("ListBooks: %v", err)
+			}
+			gotASIN := make([]string, 0, len(got))
+			for _, b := range got {
+				gotASIN = append(gotASIN, b.ASIN)
+			}
+			if !sameStringSet(gotASIN, tc.wantASIN) {
+				t.Fatalf("got %v, want %v", gotASIN, tc.wantASIN)
+			}
+		})
+	}
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := map[string]int{}
+	for _, s := range a {
+		m[s]++
+	}
+	for _, s := range b {
+		m[s]--
+	}
+	for _, n := range m {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -74,5 +74,21 @@ type BookFilter struct {
 	SortDir string // "asc", "desc"
 	Limit   int
 	Offset  int
+
+	// Presence filters. Each is independent and stacks with the others;
+	// an empty/nil value means "no filter on this dimension".
+	//
+	// OnDisk filters on whether books.file_path is non-empty. nil means
+	// either; true keeps only on-disk rows; false keeps only rows whose
+	// file is missing locally.
+	//
+	// PresentInDestinations keeps books that ARE currently synced to
+	// every listed destination (sync_state in synced|syncing).
+	// MissingFromDestinations keeps books NOT currently synced to any
+	// of the listed destinations. The two slices stack — a book is
+	// included only when it satisfies every per-destination predicate.
+	OnDisk                  *bool
+	PresentInDestinations   []string
+	MissingFromDestinations []string
 }
 

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -605,10 +605,10 @@ func buildBookWherePostgres(filter BookFilter) (string, []interface{}) {
 		paramIdx++
 	}
 	if filter.Search != "" {
-		clauses = append(clauses, fmt.Sprintf("(title ILIKE $%d OR author ILIKE $%d)", paramIdx, paramIdx+1))
+		clauses = append(clauses, fmt.Sprintf("(title ILIKE $%d OR author ILIKE $%d OR series ILIKE $%d OR asin ILIKE $%d)", paramIdx, paramIdx+1, paramIdx+2, paramIdx+3))
 		search := "%" + filter.Search + "%"
-		args = append(args, search, search)
-		paramIdx += 2
+		args = append(args, search, search, search, search)
+		paramIdx += 4
 	}
 
 	if len(clauses) == 0 {

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -610,6 +610,23 @@ func buildBookWherePostgres(filter BookFilter) (string, []interface{}) {
 		args = append(args, search, search, search, search)
 		paramIdx += 4
 	}
+	if filter.OnDisk != nil {
+		if *filter.OnDisk {
+			clauses = append(clauses, "file_path != ''")
+		} else {
+			clauses = append(clauses, "(file_path IS NULL OR file_path = '')")
+		}
+	}
+	for _, destID := range filter.PresentInDestinations {
+		clauses = append(clauses, fmt.Sprintf("EXISTS (SELECT 1 FROM book_library_destinations bld WHERE bld.book_id = books.id AND bld.destination_id = $%d AND bld.sync_state IN ('synced','syncing'))", paramIdx))
+		args = append(args, destID)
+		paramIdx++
+	}
+	for _, destID := range filter.MissingFromDestinations {
+		clauses = append(clauses, fmt.Sprintf("NOT EXISTS (SELECT 1 FROM book_library_destinations bld WHERE bld.book_id = books.id AND bld.destination_id = $%d AND bld.sync_state IN ('synced','syncing'))", paramIdx))
+		args = append(args, destID)
+		paramIdx++
+	}
 
 	if len(clauses) == 0 {
 		return "", nil

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -650,6 +650,24 @@ func buildBookWhere(filter BookFilter) (string, []interface{}) {
 		search := "%" + filter.Search + "%"
 		args = append(args, search, search, search, search)
 	}
+	if filter.OnDisk != nil {
+		if *filter.OnDisk {
+			clauses = append(clauses, "file_path != ''")
+		} else {
+			clauses = append(clauses, "(file_path IS NULL OR file_path = '')")
+		}
+	}
+	// "Present in destination" — there is a synced/syncing row for
+	// this (book, destination). The index on (destination_id, sync_state)
+	// keeps the subquery cheap.
+	for _, destID := range filter.PresentInDestinations {
+		clauses = append(clauses, "EXISTS (SELECT 1 FROM book_library_destinations bld WHERE bld.book_id = books.id AND bld.destination_id = ? AND bld.sync_state IN ('synced','syncing'))")
+		args = append(args, destID)
+	}
+	for _, destID := range filter.MissingFromDestinations {
+		clauses = append(clauses, "NOT EXISTS (SELECT 1 FROM book_library_destinations bld WHERE bld.book_id = books.id AND bld.destination_id = ? AND bld.sync_state IN ('synced','syncing'))")
+		args = append(args, destID)
+	}
 
 	if len(clauses) == 0 {
 		return "", nil

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -646,9 +646,9 @@ func buildBookWhere(filter BookFilter) (string, []interface{}) {
 		args = append(args, *filter.Status)
 	}
 	if filter.Search != "" {
-		clauses = append(clauses, "(title LIKE ? OR author LIKE ?)")
+		clauses = append(clauses, "(title LIKE ? OR author LIKE ? OR series LIKE ? OR asin LIKE ?)")
 		search := "%" + filter.Search + "%"
-		args = append(args, search, search)
+		args = append(args, search, search, search, search)
 	}
 
 	if len(clauses) == 0 {

--- a/internal/library/metadata_repair.go
+++ b/internal/library/metadata_repair.go
@@ -1,0 +1,164 @@
+package library
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mstrhakr/audplexus/internal/audio"
+	"github.com/mstrhakr/audplexus/internal/audnexus"
+	"github.com/mstrhakr/audplexus/internal/database"
+)
+
+// RepairBookMetadata scans every complete book and re-embeds metadata
+// when the file's ASIN tag is missing or doesn't match the DB record.
+// Forces TagProfileAudiobookRich so the asin/series/series-part iTunes
+// atoms are written regardless of the user's tag profile setting —
+// this phase exists specifically to make books matchable by
+// ASIN-aware servers like Audiobookshelf.
+//
+// When an audnexus client is supplied, each repaired book is enriched
+// before re-tagging so genre/copyright/description match the original
+// download. With a nil audnexus client the repair falls back to the
+// DB record alone — sufficient for the ASIN-match use case.
+//
+// Returns the number of files re-tagged.
+func RepairBookMetadata(ctx context.Context, db database.Database, ff *audio.FFmpeg, an *audnexus.Client, onProgress func(processed, total int)) (int, error) {
+	if ff == nil {
+		return 0, fmt.Errorf("ffmpeg not available")
+	}
+	completeStatus := database.BookStatusComplete
+	books, _, err := db.ListBooks(ctx, database.BookFilter{Status: &completeStatus})
+	if err != nil {
+		return 0, fmt.Errorf("list complete books: %w", err)
+	}
+	total := len(books)
+	repaired := 0
+	skipped := 0
+	failed := 0
+	for i := range books {
+		select {
+		case <-ctx.Done():
+			return repaired, ctx.Err()
+		default:
+		}
+		if onProgress != nil {
+			onProgress(i, total)
+		}
+		book := &books[i]
+		if book.FilePath == "" {
+			skipped++
+			continue
+		}
+		if _, statErr := os.Stat(book.FilePath); statErr != nil {
+			skipped++
+			continue
+		}
+		tags, err := ff.ProbeTags(ctx, book.FilePath)
+		if err != nil {
+			syncLog.Warn().Err(err).Str("path", book.FilePath).Msg("metadata_repair: probe failed")
+			failed++
+			continue
+		}
+		if !metadataNeedsRepair(book, tags) {
+			continue
+		}
+		if err := retagBookFile(ctx, ff, an, book); err != nil {
+			syncLog.Warn().Err(err).Str("path", book.FilePath).Str("asin", book.ASIN).Msg("metadata_repair: retag failed")
+			failed++
+			continue
+		}
+		repaired++
+		syncLog.Info().Str("asin", book.ASIN).Str("title", book.Title).Msg("metadata_repair: re-tagged file")
+	}
+	if onProgress != nil {
+		onProgress(total, total)
+	}
+	syncLog.Info().
+		Int("books_complete", total).
+		Int("repaired", repaired).
+		Int("skipped_missing_file", skipped).
+		Int("failed", failed).
+		Msg("metadata_repair: pass complete")
+	return repaired, nil
+}
+
+// metadataNeedsRepair returns true when the file's ASIN tag doesn't
+// match the DB record. Triggers a rich re-tag rather than touching
+// only the ASIN atom, so series/series-part land at the same time.
+func metadataNeedsRepair(book *database.Book, tags map[string]string) bool {
+	return strings.TrimSpace(tags["asin"]) != book.ASIN
+}
+
+// retagBookFile re-runs EmbedMetadata over the existing file with the
+// AudiobookRich profile. Writes to a sibling temp file and atomically
+// replaces the original on success so a crashed ffmpeg leaves the
+// original file intact.
+func retagBookFile(ctx context.Context, ff *audio.FFmpeg, an *audnexus.Client, book *database.Book) error {
+	meta, err := buildRepairMetadata(ctx, an, book)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(book.FilePath)
+	ext := filepath.Ext(book.FilePath)
+	tmp, err := os.CreateTemp(dir, ".audplexus-retag-*"+ext)
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if err := ff.EmbedMetadata(book.FilePath, tmpPath, meta); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, book.FilePath); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+// buildRepairMetadata constructs the AudiobookRich metadata set for a
+// book. Uses the audnexus enrichment path when available so the
+// repaired file ends up with the same rich tag set the initial
+// download would have produced; falls back to the DB record alone
+// when audnexus is unavailable or the network lookup fails.
+func buildRepairMetadata(ctx context.Context, an *audnexus.Client, book *database.Book) (audio.Metadata, error) {
+	if an != nil {
+		enriched, err := an.EnrichMetadata(ctx, book)
+		if err == nil && enriched != nil {
+			meta := enriched.ToAudioMetadata()
+			meta.Profile = audio.TagProfileAudiobookRich
+			return meta, nil
+		}
+	}
+	year := ""
+	if !book.ReleaseDate.IsZero() {
+		year = book.ReleaseDate.Format("2006")
+	}
+	return audio.Metadata{
+		Title:       book.Title,
+		Author:      book.Author,
+		Narrator:    book.Narrator,
+		Publisher:   book.Publisher,
+		Language:    book.Language,
+		Album:       book.Title,
+		AlbumArtist: book.Author,
+		Year:        year,
+		Comment:     book.Description,
+		Track:       book.SeriesPosition,
+		Series:      book.Series,
+		SeriesPart:  book.SeriesPosition,
+		ASIN:        book.ASIN,
+		Profile:     audio.TagProfileAudiobookRich,
+	}, nil
+}

--- a/internal/library/metadata_repair.go
+++ b/internal/library/metadata_repair.go
@@ -101,6 +101,10 @@ func retagBookFile(ctx context.Context, ff *audio.FFmpeg, an *audnexus.Client, b
 	if err != nil {
 		return err
 	}
+	origInfo, err := os.Stat(book.FilePath)
+	if err != nil {
+		return err
+	}
 
 	dir := filepath.Dir(book.FilePath)
 	ext := filepath.Ext(book.FilePath)
@@ -109,7 +113,15 @@ func retagBookFile(ctx context.Context, ff *audio.FFmpeg, an *audnexus.Client, b
 		return err
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	// Remove the placeholder so ffmpeg creates a fresh output file
+	// instead of truncating the 0600 CreateTemp file.
+	if err := os.Remove(tmpPath); err != nil {
+		return err
+	}
 	cleanup := true
 	defer func() {
 		if cleanup {
@@ -118,6 +130,9 @@ func retagBookFile(ctx context.Context, ff *audio.FFmpeg, an *audnexus.Client, b
 	}()
 
 	if err := ff.EmbedMetadata(book.FilePath, tmpPath, meta); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, origInfo.Mode().Perm()); err != nil {
 		return err
 	}
 	if err := os.Rename(tmpPath, book.FilePath); err != nil {

--- a/internal/library/sync.go
+++ b/internal/library/sync.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mstrhakr/audplexus/internal/audio"
+	"github.com/mstrhakr/audplexus/internal/audnexus"
 	"github.com/mstrhakr/audplexus/internal/database"
 	"github.com/mstrhakr/audplexus/internal/errs"
 	"github.com/mstrhakr/audplexus/internal/logging"
@@ -41,11 +43,12 @@ const (
 type SyncPhase string
 
 const (
-	PhaseAudibleSync    SyncPhase = "audible_sync"
-	PhaseFileScan       SyncPhase = "file_scan"
-	PhasePlexSync       SyncPhase = "plex_sync"
-	PhaseCollectionSync SyncPhase = "collection_sync"
-	PhaseDownloadQueue  SyncPhase = "download_queue"
+	PhaseAudibleSync     SyncPhase = "audible_sync"
+	PhaseFileScan        SyncPhase = "file_scan"
+	PhaseMetadataRepair  SyncPhase = "metadata_repair"
+	PhasePlexSync        SyncPhase = "plex_sync"
+	PhaseCollectionSync  SyncPhase = "collection_sync"
+	PhaseDownloadQueue   SyncPhase = "download_queue"
 )
 
 // DefaultFullPhases returns the standard set of sync phases in idle state.
@@ -57,6 +60,7 @@ func DefaultFullPhases() []PhaseStatus {
 	return []PhaseStatus{
 		{Name: PhaseAudibleSync, Label: "Audible Library", Status: "idle"},
 		{Name: PhaseFileScan, Label: "File System Scan", Status: "idle"},
+		{Name: PhaseMetadataRepair, Label: "Metadata Repair", Status: "idle"},
 		{Name: PhasePlexSync, Label: "Library Scan", Status: "idle"},
 		{Name: PhaseCollectionSync, Label: "Collection Sync", Status: "idle"},
 	}
@@ -175,6 +179,13 @@ type SyncService struct {
 
 	libraryDir string
 
+	// ffmpeg and audnexus are optional dependencies used by the
+	// Metadata Repair phase. Set via SetFFmpeg / SetAudnexusClient
+	// after construction so callers that don't run repair (tests,
+	// embedded use) don't have to build them.
+	ffmpeg   *audio.FFmpeg
+	audnexus *audnexus.Client
+
 	// Plex callback (set by web layer after construction)
 	plexSyncFunc      PlexSyncFunc
 	plexReconcileFunc PlexReconcileFunc
@@ -261,6 +272,19 @@ func (s *SyncService) subPhaseFnFor(phase SyncPhase) SubPhaseFn {
 			}
 		}
 	}
+}
+
+// SetFFmpeg wires the ffmpeg wrapper used by the Metadata Repair phase.
+// Optional — when nil, the repair phase fails with a clear message.
+func (s *SyncService) SetFFmpeg(ff *audio.FFmpeg) {
+	s.ffmpeg = ff
+}
+
+// SetAudnexusClient wires the audnexus client used by Metadata Repair
+// to enrich book metadata before re-tagging. Optional — when nil,
+// repair falls back to DB-only fields.
+func (s *SyncService) SetAudnexusClient(c *audnexus.Client) {
+	s.audnexus = c
 }
 
 // SetPlexSyncCallback registers the combined Plex sync function.
@@ -468,6 +492,16 @@ func (s *SyncService) RunPhase(ctx context.Context, phase SyncPhase) error {
 			s.setPhase(phase, "complete", fmt.Sprintf("%d files reconciled", reconciled))
 		}
 
+	case PhaseMetadataRepair:
+		repaired, err := RepairBookMetadata(ctx, s.db, s.ffmpeg, s.audnexus, func(processed, total int) {
+			s.updatePhaseProgress(PhaseMetadataRepair, processed, total, false)
+		})
+		if err != nil {
+			phaseErr = err
+		} else {
+			s.setPhase(phase, "complete", fmt.Sprintf("%d files re-tagged", repaired))
+		}
+
 	case PhasePlexSync:
 		if s.plexSyncFunc == nil {
 			phaseErr = fmt.Errorf("media server not configured")
@@ -619,6 +653,29 @@ func (s *SyncService) runSync(ctx context.Context, mode SyncMode) (int, error) {
 		}
 	}
 
+	// --- Phase 2b: Metadata Repair (full sync only) ---
+	// Probes every complete book and re-embeds AudiobookRich tags when
+	// the file's ASIN atom is missing or stale, so audiobook servers
+	// (Audiobookshelf in particular) can match by ID. Non-fatal:
+	// failures degrade to a "partial" sync but don't block the rest.
+	if mode == SyncModeFull {
+		if s.ffmpeg == nil {
+			s.setPhase(PhaseMetadataRepair, "skipped", "ffmpeg unavailable")
+		} else {
+			s.setPhase(PhaseMetadataRepair, "running", "Checking metadata on existing files...")
+			repaired, repairErr := RepairBookMetadata(ctx, s.db, s.ffmpeg, s.audnexus, func(processed, total int) {
+				s.updatePhaseProgress(PhaseMetadataRepair, processed, total, false)
+			})
+			if repairErr != nil {
+				s.setPhase(PhaseMetadataRepair, "failed", repairErr.Error())
+				syncLog.Warn().Err(repairErr).Msg("metadata repair phase failed")
+			} else {
+				s.setPhase(PhaseMetadataRepair, "complete", fmt.Sprintf("%d files re-tagged", repaired))
+				syncLog.Info().Int("repaired", repaired).Msg("metadata repair complete")
+			}
+		}
+	}
+
 	// --- Phase 3: Library Scan (full sync only). Phase identifier kept as
 	// PhasePlexSync for URL/JS back-compat, but user-visible messages are
 	// backend-agnostic — works for Plex, Emby, Jellyfin, ABS. ---
@@ -710,6 +767,7 @@ func (s *SyncService) buildPhases(mode SyncMode, prev []PhaseStatus) []PhaseStat
 		return []PhaseStatus{
 			defaultPhase(PhaseAudibleSync, "Audible Library"),
 			defaultPhase(PhaseFileScan, "File System Scan"),
+			defaultPhase(PhaseMetadataRepair, "Metadata Repair"),
 			defaultPhase(PhasePlexSync, "Library Scan"),
 			defaultPhase(PhaseCollectionSync, "Collection Sync"),
 		}
@@ -721,6 +779,7 @@ func (s *SyncService) buildPhases(mode SyncMode, prev []PhaseStatus) []PhaseStat
 		label string
 	}{
 		{name: PhaseFileScan, label: "File System Scan"},
+		{name: PhaseMetadataRepair, label: "Metadata Repair"},
 		{name: PhasePlexSync, label: "Library Scan"},
 		{name: PhaseCollectionSync, label: "Collection Sync"},
 	} {

--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/mstrhakr/audplexus/internal/library"
 	"github.com/mstrhakr/audplexus/internal/logging"
@@ -12,7 +13,13 @@ import (
 var schedLog = logging.Component("scheduler")
 
 // Scheduler manages periodic tasks using cron expressions.
+//
+// mu guards syncEntry, syncMode, and autoQueue. These are configured at
+// startup and can also be reconfigured live from the web settings handler,
+// so reads in runSync (driven by the cron goroutine) and writes from the
+// setters can race without it.
 type Scheduler struct {
+	mu        sync.Mutex
 	cron      *cron.Cron
 	syncSvc   *library.SyncService
 	dlMgr     *library.DownloadManager
@@ -34,24 +41,32 @@ func New(syncSvc *library.SyncService, dlMgr *library.DownloadManager) *Schedule
 
 // SetAutoQueueNew controls whether scheduled sync automatically queues new books.
 func (s *Scheduler) SetAutoQueueNew(enabled bool) {
+	s.mu.Lock()
 	s.autoQueue = enabled
+	s.mu.Unlock()
 	schedLog.Info().Bool("enabled", enabled).Msg("scheduled auto-queue-new set")
 }
 
 // SetSyncMode sets the mode used for scheduled syncs (quick or full).
 func (s *Scheduler) SetSyncMode(mode string) {
+	s.mu.Lock()
 	switch mode {
 	case "quick":
 		s.syncMode = library.SyncModeQuick
 	default:
 		s.syncMode = library.SyncModeFull
 	}
-	schedLog.Info().Str("mode", string(s.syncMode)).Msg("scheduled sync mode set")
+	resolved := s.syncMode
+	s.mu.Unlock()
+	schedLog.Info().Str("mode", string(resolved)).Msg("scheduled sync mode set")
 }
 
 // SetSyncSchedule configures the library sync cron schedule.
 // Pass an empty string to disable.
 func (s *Scheduler) SetSyncSchedule(schedule string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	// Remove previous entry if set
 	if s.syncEntry != 0 {
 		s.cron.Remove(s.syncEntry)
@@ -78,12 +93,17 @@ func (s *Scheduler) SetSyncSchedule(schedule string) error {
 }
 
 func (s *Scheduler) runSync() {
-	schedLog.Info().Str("mode", string(s.syncMode)).Msg("scheduled sync starting")
+	s.mu.Lock()
+	mode := s.syncMode
+	autoQueue := s.autoQueue
+	s.mu.Unlock()
+
+	schedLog.Info().Str("mode", string(mode)).Msg("scheduled sync starting")
 	ctx := context.Background()
 
 	var added int
 	var err error
-	switch s.syncMode {
+	switch mode {
 	case library.SyncModeQuick:
 		added, err = s.syncSvc.QuickSync(ctx)
 	default:
@@ -94,12 +114,12 @@ func (s *Scheduler) runSync() {
 			schedLog.Info().Msg("sync already running, skipping scheduled run")
 			return
 		}
-		schedLog.Error().Err(err).Str("mode", string(s.syncMode)).Msg("scheduled sync failed")
+		schedLog.Error().Err(err).Str("mode", string(mode)).Msg("scheduled sync failed")
 		return
 	}
-	schedLog.Info().Int("added", added).Str("mode", string(s.syncMode)).Msg("scheduled sync complete")
+	schedLog.Info().Int("added", added).Str("mode", string(mode)).Msg("scheduled sync complete")
 
-	if added > 0 && s.autoQueue {
+	if added > 0 && autoQueue {
 		queued, err := s.dlMgr.QueueNewBooks(ctx)
 		if err != nil {
 			schedLog.Error().Err(err).Msg("failed to queue new books after sync")

--- a/internal/web/destinations_handlers.go
+++ b/internal/web/destinations_handlers.go
@@ -122,10 +122,9 @@ func destinationConfigured(d *database.LibraryDestination) bool {
 // (item count, coverage, last error) and a clear top-level CTA to add more.
 func (s *Server) handleDestinations(c *gin.Context) {
 	ctx := c.Request.Context()
-	completeStatus := database.BookStatusComplete
-	_, completeBooks, _ := s.db.ListBooks(ctx, database.BookFilter{Status: &completeStatus, Limit: 1})
+	_, libraryTotal, _ := s.db.ListBooks(ctx, database.BookFilter{Limit: 1})
 
-	dests := s.destinationSummaries(ctx, completeBooks)
+	dests := s.destinationSummaries(ctx, libraryTotal)
 
 	healthy := 0
 	for _, d := range dests {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mstrhakr/audplexus/internal/logging"
 	"github.com/mstrhakr/audplexus/internal/mediaserver"
 	"github.com/mstrhakr/audplexus/internal/organizer"
+	"github.com/mstrhakr/audplexus/internal/scheduler"
 	audible "github.com/mstrhakr/go-audible"
 	"github.com/robfig/cron/v3"
 )
@@ -53,6 +54,7 @@ type Server struct {
 	db             database.Database
 	sync           *library.SyncService
 	downloads      *library.DownloadManager
+	sched          *scheduler.Scheduler
 	audnexus       *audnexus.Client
 	organizer      *organizer.PlexOrganizer
 	audible        *audible.Client
@@ -93,6 +95,7 @@ func NewServer(
 	db database.Database,
 	syncSvc *library.SyncService,
 	dlMgr *library.DownloadManager,
+	sched *scheduler.Scheduler,
 	anClient *audnexus.Client,
 	org *organizer.PlexOrganizer,
 	audibleClient *audible.Client,
@@ -112,6 +115,7 @@ func NewServer(
 		db:             db,
 		sync:           syncSvc,
 		downloads:      dlMgr,
+		sched:          sched,
 		audnexus:       anClient,
 		organizer:      org,
 		audible:        audibleClient,
@@ -2965,27 +2969,42 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		return true
 	}
 
+	// Sync settings apply live via the scheduler — no restart needed. The
+	// schedule and enabled flag are coupled (enabled gates whether the cron
+	// entry exists), so reapply the effective schedule whenever either moves.
+	scheduleChanged := false
 	if _, ok := c.GetPostForm("sync_schedule_sent"); ok {
 		schedule := strings.TrimSpace(c.PostForm("sync_schedule"))
 		if setSetting("sync_schedule", schedule) {
-			restartRequired = true
+			scheduleChanged = true
 		}
 	}
 	if _, ok := c.GetPostForm("sync_enabled_sent"); ok {
 		enabled := c.PostForm("sync_enabled") == "true"
 		if setSetting("sync_enabled", strconv.FormatBool(enabled)) {
-			restartRequired = true
+			scheduleChanged = true
 		}
 	}
 	if _, ok := c.GetPostForm("sync_auto_queue_new_sent"); ok {
 		enabled := c.PostForm("sync_auto_queue_new") == "true"
-		if setSetting(library.SettingKeyAutoQueueNewBooks, strconv.FormatBool(enabled)) {
-			restartRequired = true
+		if setSetting(library.SettingKeyAutoQueueNewBooks, strconv.FormatBool(enabled)) && s.sched != nil {
+			s.sched.SetAutoQueueNew(enabled)
 		}
 	}
 	if mode := strings.TrimSpace(c.PostForm("sync_mode")); mode != "" {
-		if setSetting("sync_mode", mode) {
-			restartRequired = true
+		if setSetting("sync_mode", mode) && s.sched != nil {
+			s.sched.SetSyncMode(mode)
+		}
+	}
+	if scheduleChanged && s.sched != nil {
+		enabled := s.settingBool(ctx, "sync_enabled", true)
+		schedule := strings.TrimSpace(s.settingString(ctx, "sync_schedule", ""))
+		applied := ""
+		if enabled {
+			applied = schedule
+		}
+		if err := s.sched.SetSyncSchedule(applied); err != nil {
+			webLog.Error().Err(err).Str("schedule", applied).Msg("failed to apply sync schedule live")
 		}
 	}
 	if raw := c.PostForm("output_format"); raw != "" {
@@ -3062,7 +3081,7 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 	if c.GetHeader("HX-Request") == "true" {
 		msg := "Settings saved"
 		if restartRequired {
-			msg = "Settings saved. Restart required to apply one or more changes."
+			msg = "Settings saved. Worker count changes need a restart to take effect."
 		}
 		c.HTML(http.StatusOK, "settings_saved.html", gin.H{"Message": msg, "RestartRequired": restartRequired})
 		return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	audnexus       *audnexus.Client
 	organizer      *organizer.PlexOrganizer
 	audible        *audible.Client
+	ffmpeg         *audio.FFmpeg
 	credPath       string
 	port           int
 	audiobooksPath string
@@ -95,6 +96,7 @@ func NewServer(
 	anClient *audnexus.Client,
 	org *organizer.PlexOrganizer,
 	audibleClient *audible.Client,
+	ffmpeg *audio.FFmpeg,
 	credPath string,
 	port int,
 	audiobooksPath string,
@@ -113,6 +115,7 @@ func NewServer(
 		audnexus:       anClient,
 		organizer:      org,
 		audible:        audibleClient,
+		ffmpeg:         ffmpeg,
 		credPath:       credPath,
 		port:           port,
 		audiobooksPath: audiobooksPath,
@@ -1287,6 +1290,7 @@ func (s *Server) handleBookDetail(c *gin.Context) {
 	}
 
 	folderPath, files := buildBookFileDetails(book.FilePath)
+	fileInfo := s.buildBookFileInfo(ctx, book)
 
 	data := gin.H{
 		"Book":          book,
@@ -1294,6 +1298,7 @@ func (s *Server) handleBookDetail(c *gin.Context) {
 		"BookFolderPath": folderPath,
 		"BookFiles":     files,
 		"BookFileCount": len(files),
+		"BookFileInfo":  fileInfo,
 		"BookAction":    buildLibraryBookActions([]database.Book{*book}, s.settingBool(ctx, library.SettingKeyAutoQueueNewBooks, false))[book.ID],
 		"BookDestinationStatuses": s.bookDestinationStatuses(ctx, book.ID),
 	}
@@ -1432,6 +1437,225 @@ func isAudioFile(path string) bool {
 	default:
 		return false
 	}
+}
+
+// bookFileInfoTag is one row of the raw-tag list on the File info
+// block. Stays as a slice rather than a map so the template can render
+// in a deterministic order — the ffprobe map iteration order is
+// otherwise nondeterministic and shuffles between requests.
+type bookFileInfoTag struct {
+	Key   string
+	Value string
+}
+
+// bookFileInfoView is the view-model for the "File info" block on
+// Book Details. Every field is independently optional — the template
+// uses zero values + an empty tag list to silently omit rows so a
+// degraded probe (file moved, container quirks) still renders a
+// useful partial card instead of a hard failure.
+type bookFileInfoView struct {
+	Path            string
+	Extension       string
+	SizeBytes       int64
+	SizeLabel       string
+	ModifiedAt      string
+	Format          string
+	Codec           string
+	CodecLong       string
+	BitRate         string
+	SampleRate      string
+	Channels        string
+	ChapterCount    int
+	HasArtwork      bool
+	Duration        string
+	ActivationBytes string
+	Tags            []bookFileInfoTag
+	ProbeError      string
+}
+
+// buildBookFileInfo populates the File info block for a book that is
+// known to be on disk. Returns nil for books with no FilePath so the
+// template can skip the whole section with a single nil check.
+//
+// The function tolerates partial failures: a missing file still
+// surfaces what's in the DB; a probe that errors leaves Format/etc
+// blank but keeps the size/modified-time rows. Activation bytes are
+// fetched from the audible client when available (account-scoped),
+// since they're what was used to decrypt this file — handy for
+// re-decryption.
+func (s *Server) buildBookFileInfo(ctx context.Context, book *database.Book) *bookFileInfoView {
+	if book == nil || strings.TrimSpace(book.FilePath) == "" {
+		return nil
+	}
+
+	v := &bookFileInfoView{
+		Path:      book.FilePath,
+		Extension: strings.TrimPrefix(strings.ToLower(filepath.Ext(book.FilePath)), "."),
+	}
+
+	if info, err := os.Stat(book.FilePath); err == nil && !info.IsDir() {
+		v.SizeBytes = info.Size()
+		v.SizeLabel = humanFileSize(info.Size())
+		v.ModifiedAt = info.ModTime().Format("2006-01-02 15:04")
+	}
+
+	if s.ffmpeg != nil {
+		probeCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+		defer cancel()
+		probe, err := s.ffmpeg.ProbeFile(probeCtx, book.FilePath)
+		if err != nil {
+			v.ProbeError = err.Error()
+		} else if probe != nil {
+			if probe.FormatLongName != "" {
+				v.Format = probe.FormatLongName
+			} else {
+				v.Format = probe.FormatName
+			}
+			v.Codec = probe.AudioCodec
+			v.CodecLong = probe.AudioCodecLong
+			v.BitRate = formatProbeBitRate(probe.AudioBitRate, probe.BitRate)
+			v.SampleRate = formatSampleRate(probe.SampleRate)
+			v.Channels = formatChannels(probe.Channels, probe.ChannelLayout)
+			v.ChapterCount = probe.ChapterCount
+			v.HasArtwork = probe.HasArtwork
+			if probe.DurationSec > 0 {
+				v.Duration = formatDurationSeconds(probe.DurationSec)
+			}
+			// Size from ffprobe wins when stat failed (rare; usually
+			// the same number).
+			if v.SizeBytes == 0 && probe.Size > 0 {
+				v.SizeBytes = probe.Size
+				v.SizeLabel = humanFileSize(probe.Size)
+			}
+			v.Tags = sortedProbeTags(probe.Tags)
+		}
+	}
+
+	// Activation bytes are per-account, not per-book — but the field
+	// belongs on the file-info card because they're the secret that
+	// decrypted this particular file. Skip silently when the audible
+	// client isn't authenticated or the call errors.
+	if s.audible != nil && s.audible.IsAuthenticated() {
+		abCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		if resp, err := s.audible.GetActivationBytes(abCtx); err == nil && resp != nil {
+			v.ActivationBytes = resp.ActivationBytes
+		}
+	}
+
+	return v
+}
+
+// formatProbeBitRate picks the most informative of two bit-rate
+// candidates (audio stream first, container second) and converts
+// bits/sec → "128 kb/s". ffprobe sometimes reports "0" or "" for
+// the audio stream on lossy containers — fall back to the container.
+func formatProbeBitRate(streamBPS, containerBPS string) string {
+	pick := streamBPS
+	if pick == "" || pick == "0" {
+		pick = containerBPS
+	}
+	if pick == "" || pick == "0" {
+		return ""
+	}
+	var bps int64
+	if _, err := fmt.Sscanf(pick, "%d", &bps); err != nil || bps <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d kb/s", bps/1000)
+}
+
+func formatSampleRate(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var hz int64
+	if _, err := fmt.Sscanf(raw, "%d", &hz); err != nil || hz <= 0 {
+		return ""
+	}
+	if hz%1000 == 0 {
+		return fmt.Sprintf("%d kHz", hz/1000)
+	}
+	return fmt.Sprintf("%.1f kHz", float64(hz)/1000.0)
+}
+
+func formatChannels(n int, layout string) string {
+	if n <= 0 {
+		return ""
+	}
+	if layout != "" {
+		return fmt.Sprintf("%d (%s)", n, layout)
+	}
+	switch n {
+	case 1:
+		return "1 (mono)"
+	case 2:
+		return "2 (stereo)"
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func formatDurationSeconds(sec float64) string {
+	total := int(sec)
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm %ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}
+
+// sortedProbeTags returns the tag map as a slice. Container-level
+// identity tags (encoder, major_brand, asin, series) bubble to the
+// top so the most useful info renders first; the rest sort
+// alphabetically. Empty values are dropped.
+func sortedProbeTags(tags map[string]string) []bookFileInfoTag {
+	if len(tags) == 0 {
+		return nil
+	}
+	priority := map[string]int{
+		"encoder":           1,
+		"major_brand":       2,
+		"minor_version":     3,
+		"compatible_brands": 4,
+		"asin":              5,
+		"series":            6,
+		"series-part":       7,
+		"title":             8,
+		"artist":            9,
+		"album_artist":      10,
+		"album":             11,
+		"date":              12,
+		"genre":             13,
+		"language":          14,
+		"media_type":        15,
+	}
+	out := make([]bookFileInfoTag, 0, len(tags))
+	for k, val := range tags {
+		if strings.TrimSpace(val) == "" {
+			continue
+		}
+		out = append(out, bookFileInfoTag{Key: k, Value: val})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		pi, oki := priority[out[i].Key]
+		pj, okj := priority[out[j].Key]
+		switch {
+		case oki && okj:
+			return pi < pj
+		case oki:
+			return true
+		case okj:
+			return false
+		default:
+			return out[i].Key < out[j].Key
+		}
+	})
+	return out
 }
 
 func humanFileSize(sizeBytes int64) string {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1281,13 +1281,16 @@ func hasFilesWithExt(dirPath string, ext string) bool {
 func (s *Server) handleBookDetail(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var id int64
-	if _, err := fmt.Sscanf(c.Param("id"), "%d", &id); err != nil {
-		c.HTML(http.StatusBadRequest, "dashboard.html", gin.H{"Error": "Invalid book ID"})
-		return
+	// Accept either a numeric book ID or an ASIN. Links from Diagnostics
+	// (and other ASIN-keyed surfaces) pass the ASIN, which isn't numeric.
+	param := strings.TrimSpace(c.Param("id"))
+	var book *database.Book
+	var err error
+	if id, perr := strconv.ParseInt(param, 10, 64); perr == nil {
+		book, err = s.db.GetBook(ctx, id)
+	} else {
+		book, err = s.db.GetBookByASIN(ctx, param)
 	}
-
-	book, err := s.db.GetBook(ctx, id)
 	if err != nil || book == nil {
 		c.HTML(http.StatusNotFound, "dashboard.html", gin.H{"Error": "Book not found"})
 		return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -702,7 +702,11 @@ func (s *Server) getDashboardSummaryData(ctx context.Context) gin.H {
 		// Per-destination summary cards. Replaces the legacy
 		// single-active-backend stat cards. Empty slice means "no
 		// destinations configured yet" — template shows a CTA.
-		"DestinationSummaries": s.destinationSummaries(ctx, completeBooks),
+		// Coverage % uses totalBooks (Audible library size) as the
+		// denominator so it represents "fraction of the library present
+		// in this destination" — stable across status transitions and
+		// matches the user's mental model.
+		"DestinationSummaries": s.destinationSummaries(ctx, totalBooks),
 	}
 }
 
@@ -750,7 +754,7 @@ type destinationSummaryView struct {
 //
 // Per a11y-lead: badges are role="status" so SR users hear destination
 // state changes (Healthy → Failed) without per-tick count chatter.
-func (s *Server) destinationSummaries(ctx context.Context, completeBooks int) []destinationSummaryView {
+func (s *Server) destinationSummaries(ctx context.Context, libraryTotal int) []destinationSummaryView {
 	rows, err := s.db.ListLibraryDestinations(ctx)
 	if err != nil {
 		webLog.Warn().Err(err).Msg("dashboard: list destinations failed")
@@ -763,7 +767,7 @@ func (s *Server) destinationSummaries(ctx context.Context, completeBooks int) []
 	out := make([]destinationSummaryView, 0, len(rows))
 	for _, r := range rows {
 		row := r
-		out = append(out, s.buildDestinationSummary(ctx, &row, completeBooks))
+		out = append(out, s.buildDestinationSummary(ctx, &row, libraryTotal))
 	}
 	return out
 }
@@ -778,12 +782,11 @@ func (s *Server) singleDestinationSummary(ctx context.Context, id string) *desti
 	if err != nil || row == nil {
 		return nil
 	}
-	// Coverage % is relative to the count of complete books; we need
-	// that number for the meter to render the same as it does on the
-	// full grid. Cheap LIMIT-1 count.
-	completeStatus := database.BookStatusComplete
-	_, completeBooks, _ := s.db.ListBooks(ctx, database.BookFilter{Status: &completeStatus, Limit: 1})
-	v := s.buildDestinationSummary(ctx, row, completeBooks)
+	// Coverage % uses the total library size as the denominator so the
+	// meter renders the same as it does on the full grid. Cheap
+	// LIMIT-1 count.
+	_, libraryTotal, _ := s.db.ListBooks(ctx, database.BookFilter{Limit: 1})
+	v := s.buildDestinationSummary(ctx, row, libraryTotal)
 	return &v
 }
 
@@ -791,7 +794,7 @@ func (s *Server) singleDestinationSummary(ctx context.Context, id string) *desti
 // builder and the single-row swap path. Probes LibraryItemCount (with
 // the 30s cache) only for enabled+configured destinations so toggling
 // a disabled row stays cheap.
-func (s *Server) buildDestinationSummary(ctx context.Context, row *database.LibraryDestination, completeBooks int) destinationSummaryView {
+func (s *Server) buildDestinationSummary(ctx context.Context, row *database.LibraryDestination, libraryTotal int) destinationSummaryView {
 	hasCred := row.APIKey != "" || row.PlexToken != ""
 	v := destinationSummaryView{
 		ID:              row.ID,
@@ -832,8 +835,8 @@ func (s *Server) buildDestinationSummary(ctx context.Context, row *database.Libr
 	}
 	v.ItemCount = count
 	v.ItemCountSet = true
-	if completeBooks > 0 {
-		cov := int(math.Round((float64(count) / float64(completeBooks)) * 100))
+	if libraryTotal > 0 {
+		cov := int(math.Round((float64(count) / float64(libraryTotal)) * 100))
 		if cov < 0 {
 			cov = 0
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3426,8 +3426,8 @@ func (s *Server) handleAuthCallback(c *gin.Context) {
 	webLog.Info().Msg("authentication successful")
 
 	// If the user is still in onboarding, bounce back into the wizard at
-	// the Storage step rather than dropping them on Settings — the wizard
-	// is what kicked them out to Amazon in the first place.
+	// the Destinations step rather than dropping them on Settings — the
+	// wizard is what kicked them out to Amazon in the first place.
 	if s.isFirstRun(ctx) {
 		c.Redirect(http.StatusSeeOther, "/setup?step=2")
 		return

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1004,6 +1004,34 @@ func (s *Server) handleLibrary(c *gin.Context) {
 		filter.Status = &status
 	}
 
+	// Presence filters. on_disk is a tri-state: missing/empty = any,
+	// "yes" = on disk, "no" = missing locally. Per-destination filters
+	// arrive as presence_<dest_id>=in|out — iterating the raw query
+	// keeps the param list extensible as the user adds destinations.
+	switch c.Query("on_disk") {
+	case "yes":
+		v := true
+		filter.OnDisk = &v
+	case "no":
+		v := false
+		filter.OnDisk = &v
+	}
+	destFilterState := map[string]string{}
+	for key, vals := range c.Request.URL.Query() {
+		if !strings.HasPrefix(key, "presence_") || len(vals) == 0 {
+			continue
+		}
+		destID := strings.TrimPrefix(key, "presence_")
+		switch vals[0] {
+		case "in":
+			filter.PresentInDestinations = append(filter.PresentInDestinations, destID)
+			destFilterState[destID] = "in"
+		case "out":
+			filter.MissingFromDestinations = append(filter.MissingFromDestinations, destID)
+			destFilterState[destID] = "out"
+		}
+	}
+
 	books, total, err := s.db.ListBooks(ctx, filter)
 	if err != nil {
 		webLog.Error().Err(err).Msg("failed to list books")
@@ -1025,20 +1053,22 @@ func (s *Server) handleLibrary(c *gin.Context) {
 	}
 
 	data := gin.H{
-		"Books":        books,
-		"Total":        total,
-		"Filter":       filter,
-		"Page":         "library",
-		"BookActions":  buildLibraryBookActions(books, s.settingBool(ctx, library.SettingKeyAutoQueueNewBooks, false)),
-		"BookPresence": s.computeBookPresence(ctx, books),
-		"StatusCounts": counts,
-		"ActiveStatus": statusStr,
-		"PageNum":      pageNum,
-		"TotalPages":   totalPages,
-		"PageSize":     pageSize,
-		"PageFrom":     from,
-		"PageTo":       to,
-		"PageNums":     paginationNumbers(pageNum, totalPages),
+		"Books":             books,
+		"Total":             total,
+		"Filter":            filter,
+		"Page":              "library",
+		"BookActions":       buildLibraryBookActions(books, s.settingBool(ctx, library.SettingKeyAutoQueueNewBooks, false)),
+		"BookPresence":      s.computeBookPresence(ctx, books),
+		"StatusCounts":      counts,
+		"ActiveStatus":      statusStr,
+		"PresenceFilters":   s.libraryPresenceFilterOpts(ctx, destFilterState),
+		"OnDiskFilter":      c.Query("on_disk"),
+		"PageNum":           pageNum,
+		"TotalPages":        totalPages,
+		"PageSize":          pageSize,
+		"PageFrom":          from,
+		"PageTo":            to,
+		"PageNums":          paginationNumbers(pageNum, totalPages),
 	}
 
 	// For HTMX partial requests, render only the table body
@@ -1047,6 +1077,37 @@ func (s *Server) handleLibrary(c *gin.Context) {
 		return
 	}
 	c.HTML(http.StatusOK, "library.html", s.withSidebar(ctx, data))
+}
+
+// libraryPresenceFilterOption is one row in the per-destination presence
+// dropdown — rendered as a <select> in the filter bar.
+type libraryPresenceFilterOption struct {
+	ID          string
+	DisplayName string
+	State       string // "" | "in" | "out" — current selection
+}
+
+// libraryPresenceFilterOpts returns one option entry per enabled
+// library destination, carrying the currently-selected state from the
+// URL so the dropdown re-renders with the right option selected after
+// an HTMX swap.
+func (s *Server) libraryPresenceFilterOpts(ctx context.Context, state map[string]string) []libraryPresenceFilterOption {
+	dests, err := s.db.ListLibraryDestinations(ctx)
+	if err != nil {
+		return nil
+	}
+	out := make([]libraryPresenceFilterOption, 0, len(dests))
+	for _, d := range dests {
+		if !d.Enabled {
+			continue
+		}
+		out = append(out, libraryPresenceFilterOption{
+			ID:          d.ID,
+			DisplayName: d.DisplayName,
+			State:       state[d.ID],
+		})
+	}
+	return out
 }
 
 // libraryStatusCounts returns the count of books per status bucket used by

--- a/internal/web/setup_handlers.go
+++ b/internal/web/setup_handlers.go
@@ -129,13 +129,25 @@ func (s *Server) handleSetupFinish(c *gin.Context) {
 	// step. An unchecked toggle submits nothing, so absence means off.
 	autoDownload := c.PostForm("auto_queue_new") == "true"
 	_ = s.db.SetSetting(ctx, library.SettingKeyAutoQueueNewBooks, strconv.FormatBool(autoDownload))
+	if s.sched != nil {
+		s.sched.SetAutoQueueNew(autoDownload)
+	}
 
 	if s.audible.IsAuthenticated() {
 		// Fire-and-forget — sync runs asynchronously; UI will show progress
 		// via the existing /api/sync/status polling on the dashboard.
 		go func() {
-			if _, err := s.sync.QuickSync(context.Background()); err != nil {
+			added, err := s.sync.QuickSync(context.Background())
+			if err != nil {
 				webLog.Warn().Err(err).Msg("setup: first quick sync failed")
+				return
+			}
+			if autoDownload && added > 0 {
+				if queued, qErr := s.downloads.QueueNewBooks(context.Background()); qErr != nil {
+					webLog.Warn().Err(qErr).Int("added", added).Msg("setup: failed to auto-queue new books after first quick sync")
+				} else {
+					webLog.Info().Int("added", added).Int("queued", queued).Msg("setup: auto-queued new books after first quick sync")
+				}
 			}
 		}()
 	}

--- a/internal/web/setup_handlers.go
+++ b/internal/web/setup_handlers.go
@@ -27,9 +27,8 @@ type setupStep struct {
 var setupSteps = []setupStep{
 	{NumLabel: "1", Label: "Welcome"},
 	{NumLabel: "2", Label: "Audible"},
-	{NumLabel: "3", Label: "Storage"},
-	{NumLabel: "4", Label: "Destinations"},
-	{NumLabel: "5", Label: "Done"},
+	{NumLabel: "3", Label: "Destinations"},
+	{NumLabel: "4", Label: "Done"},
 }
 
 // isFirstRun returns true when the wizard has neither been completed nor
@@ -83,7 +82,6 @@ func (s *Server) handleSetupWizard(c *gin.Context) {
 	data["Steps"] = setupSteps
 	data["CurrentStep"] = step
 	data["AudiobooksPath"] = s.audiobooksPath
-	data["DownloadsPath"] = s.downloadsPath
 
 	// Destinations summary for steps 3 (list) and 4 (recap). We use the
 	// rich destinationSummaries shape so the picker-list shows type +

--- a/internal/web/setup_handlers.go
+++ b/internal/web/setup_handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mstrhakr/audplexus/internal/database"
+	"github.com/mstrhakr/audplexus/internal/library"
 )
 
 // settingKeyOnboarded marks the setup wizard as completed. Stored as "1"
@@ -125,6 +126,11 @@ func (s *Server) handleSetupMarketplace(c *gin.Context) {
 func (s *Server) handleSetupFinish(c *gin.Context) {
 	ctx := c.Request.Context()
 	_ = s.setOnboarded(ctx, true)
+
+	// Persist the "automatically download new books" choice from the final
+	// step. An unchecked toggle submits nothing, so absence means off.
+	autoDownload := c.PostForm("auto_queue_new") == "true"
+	_ = s.db.SetSetting(ctx, library.SettingKeyAutoQueueNewBooks, strconv.FormatBool(autoDownload))
 
 	if s.audible.IsAuthenticated() {
 		// Fire-and-forget — sync runs asynchronously; UI will show progress

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -3268,7 +3268,6 @@ a.btn, a.btn:hover, a.btn:visited { text-decoration: none; }
     height: 22px;
     border-radius: 6px;
     border: 1px solid var(--border);
-    background: var(--surface-2);
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -466,6 +466,23 @@ h2 { margin: 1.5rem 0 0.75rem; font-size: 1.2rem; color: var(--text-muted); }
 .stat-grid .stat-card .delta.down  { color: #ff7c7c; }
 .stat-grid .stat-card .delta.warn  { color: #ffb547; }
 
+/* Clickable variant — anchor styled as a card. No text decoration,
+   subtle hover lift so the affordance is visible without trumpeting it. */
+.stat-grid .stat-card.stat-card-link {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+}
+.stat-grid .stat-card.stat-card-link:hover {
+    border-color: var(--accent);
+    background: var(--surface-2);
+}
+.stat-grid .stat-card.stat-card-link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* Filter tabs (Library) */
 .tabs {
     display: flex;
@@ -2624,30 +2641,159 @@ a.btn, a.btn:hover, a.btn:visited { text-decoration: none; }
     font-weight: 600;
 }
 
+/* Hamburger toggle — hidden on desktop, shown alongside the topbar
+   breadcrumb on mobile. Styled like a ghost icon button so the affordance
+   reads as utility, not a primary action. */
+.nav-toggle {
+    display: none;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 7px;
+    padding: 0.35rem 0.45rem;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+}
+.nav-toggle:hover { background: var(--surface-2); }
+.nav-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* Backdrop is always in the DOM so transitions are cheap; only made
+   interactive when the drawer is open. */
+.sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 40;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+body.sidebar-open .sidebar-backdrop {
+    opacity: 1;
+    pointer-events: auto;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .sync-phases { gap: 0.25rem; }
     .sync-phase { flex-basis: 100%; }
+
+    /* Sidebar becomes an off-canvas drawer. transform keeps the
+       animation on the compositor and avoids reflowing the page. */
     .sidebar {
-        width: 100%;
-        position: relative;
-        flex-direction: row;
-        border-right: none;
-        border-bottom: 1px solid var(--border);
+        width: 260px;
+        transform: translateX(-100%);
+        transition: transform 0.22s ease;
+        z-index: 50;
+        flex-direction: column;
+        border-right: 1px solid var(--border);
+        border-bottom: none;
     }
-    .sidebar-header { display: none; }
-    .nav-links { display: flex; }
-    .nav-links li a { padding: 0.75rem; }
+    body.sidebar-open .sidebar { transform: translateX(0); }
+    .sidebar-header { display: flex; }
+    .nav-links { display: block; }
+    .nav-links li a { padding: 0.65rem 1rem; }
+
     .main { margin-left: 0; width: 100%; }
     .content { margin-left: 0; padding: 1rem; }
-    .topbar { padding: 0 1rem; }
+    .topbar { padding: 0 1rem; gap: 0.65rem; }
     .topbar-search { min-width: 0; flex: 1; }
+    .nav-toggle { display: inline-flex; }
+
     body { flex-direction: column; }
     .book-detail { flex-direction: column; }
     .stats-grid { grid-template-columns: repeat(2, 1fr); }
     .settings-page { max-width: 100%; }
     .auth-panel { padding: 1rem; border-radius: 10px; }
     .destination-type-grid { grid-template-columns: 1fr; }
+
+    /* Library table → card view. Tables can't reflow on narrow viewports
+       without horizontal scroll or this CSS-flip; we choose the flip so
+       the row remains scannable on a phone. Named column classes
+       (col-title, col-author, …) on the row template keep this robust
+       against future column reorders. */
+    .table-wrap { overflow-x: visible; }
+    #book-table .tbl,
+    #book-table .tbl tbody,
+    #book-table .tbl tr {
+        display: block;
+        width: 100%;
+        border: none;
+    }
+    #book-table .tbl thead { display: none; }
+    #book-table .tbl tr {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0.75rem 0.85rem 0.55rem;
+        margin-bottom: 0.6rem;
+        position: relative;
+    }
+    /* Clearfix for the floated cover. */
+    #book-table .tbl tr::after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+    #book-table .tbl tr > td {
+        display: block;
+        padding: 0;
+        border: none;
+        text-align: left;
+        white-space: normal;
+        vertical-align: baseline;
+    }
+
+    /* Cover floats left so subsequent cells wrap around it. */
+    #book-table .tbl .col-cover {
+        float: left;
+        width: 60px;
+        margin: 0 0.7rem 0.4rem 0;
+    }
+    #book-table .tbl .col-cover img,
+    #book-table .tbl .col-cover .cover-thumb-placeholder {
+        width: 60px;
+        height: 90px;
+        display: block;
+    }
+
+    /* Block lines for title / author / series. */
+    #book-table .tbl .col-title  { font-size: 0.93rem; line-height: 1.3; margin-bottom: 0.1rem; }
+    #book-table .tbl .col-author { color: var(--text-muted); font-size: 0.82rem; }
+    #book-table .tbl .col-series { font-size: 0.78rem; }
+    /* Skip the "—" placeholder cell so empty series doesn't leave a gap. */
+    #book-table .tbl .col-series:has(.cell-mono:only-child) { display: none; }
+
+    /* Metrics row: duration + purchased + status + presence, all
+       inline-flex so they pack into one wrapping line under the
+       block fields above. */
+    #book-table .tbl .col-duration,
+    #book-table .tbl .col-purchased,
+    #book-table .tbl .col-status,
+    #book-table .tbl .col-presence {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        margin: 0.25rem 0.55rem 0 0;
+        font-size: 0.78rem;
+        vertical-align: middle;
+    }
+    #book-table .tbl .col-presence { flex-wrap: wrap; }
+
+    /* Actions clear the cover float and span full card width. */
+    #book-table .tbl .col-actions {
+        clear: both;
+        margin-top: 0.55rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid var(--border);
+        text-align: left;
+        width: auto;
+        white-space: normal;
+    }
+    #book-table .tbl .col-actions .table-actions { justify-content: flex-start; }
+
+    #book-table .table-pagination { display: block; }
 }
 
 /* =====================================================================

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -2010,6 +2010,75 @@ a.btn, a.btn:hover, a.btn:visited { text-decoration: none; }
     margin: 0.25rem 0;
 }
 
+/* Collapsible description — clamps to ~9.5rem with a fade-out, then
+   the JS-driven toggle below flips the class to reveal the rest. */
+.book-description {
+    position: relative;
+    margin-top: 0.5rem;
+}
+.book-description-clamp {
+    max-height: 9.5rem;
+    overflow: hidden;
+    position: relative;
+}
+.book-description-clamp::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3rem;
+    pointer-events: none;
+    background: linear-gradient(to bottom,
+        rgba(22, 33, 62, 0) 0%,
+        var(--surface) 100%);
+}
+.book-description-toggle {
+    margin-top: 0.5rem;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    color: var(--accent);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+}
+.book-description-toggle:hover { text-decoration: underline; }
+
+/* File info — same meta-grid recipe as the top-of-card metadata,
+   but path/tag rows can be long so they break on word boundaries. */
+.book-file-info-grid {
+    margin-top: 0.5rem;
+}
+.book-file-info-path {
+    word-break: break-all;
+    font-size: 0.78rem;
+}
+.book-file-tags-details {
+    margin-top: 0.6rem;
+}
+.book-file-tags-details > summary {
+    display: inline-block;
+    cursor: pointer;
+    color: #9cc9ff;
+    padding: 0.35rem 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: rgba(15, 52, 96, 0.35);
+    user-select: none;
+    font-size: 0.82rem;
+}
+.book-file-tags-details[open] > summary { margin-bottom: 0.55rem; }
+.book-file-tags-grid {
+    grid-template-columns: max-content 1fr;
+    gap: 0.2rem 0.75rem;
+    font-size: 0.78rem;
+}
+.book-file-tag-value {
+    word-break: break-word;
+    max-width: 100%;
+}
+
 /* Progress bar */
 .progress-bar {
     height: 8px;

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -822,7 +822,7 @@
                         if (empty) empty.remove();
                         var tr = document.createElement('tr');
                         var label = d.title || d.asin;
-                        tr.innerHTML = '<td>' + d.asin + '</td><td>' + label + '</td><td>just now</td>';
+                        tr.innerHTML = '<td>' + escHTML(label) + '</td><td class="cell-mono">' + escHTML(d.asin) + '</td><td>just now</td>';
                         cb.insertBefore(tr, cb.firstChild);
                         adj('complete-count', 1);
                     }
@@ -837,7 +837,7 @@
                         var tr = document.createElement('tr');
                         var label = d.title || d.asin;
                         var errMsg = d.error || 'unknown error';
-                        tr.innerHTML = '<td>' + d.asin + '</td><td class="error-text">' + errMsg + '</td><td>' + label + '</td>';
+                        tr.innerHTML = '<td>' + escHTML(label) + '</td><td class="cell-mono">' + escHTML(d.asin) + '</td><td class="error-text">' + escHTML(errMsg) + '</td>';
                         fb.insertBefore(tr, fb.firstChild);
                         adj('failed-count', 1);
                     }

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -13,7 +13,8 @@
     {{$sb := .Sidebar}}
     {{$isWizard := eq .Page "setup"}}
     {{if not $isWizard}}
-    <nav class="sidebar">
+    <div class="sidebar-backdrop" data-nav-dismiss aria-hidden="true"></div>
+    <nav class="sidebar" id="primary-nav">
         <div class="sidebar-header">
             <img src="/static/logo.svg" alt="Audplexus Logo" class="sidebar-logo" />
             <div class="sidebar-brand">
@@ -76,6 +77,10 @@
         {{$pageLabels := dict "dashboard" "Dashboard" "library" "Library" "pipeline" "Pipeline" "destinations" "Destinations" "destinations_new_picker" "Destinations" "destinations_new_form" "Destinations" "diagnostics" "Diagnostics" "settings" "Settings"}}
         {{$current := index $pageLabels .Page}}
         <header class="topbar" role="banner">
+            <button type="button" class="nav-toggle" aria-label="Open navigation"
+                    aria-controls="primary-nav" aria-expanded="false" data-nav-toggle>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+            </button>
             <nav class="crumbs" aria-label="Breadcrumb">
                 <span>Audplexus</span>
                 {{if $current}}
@@ -572,7 +577,14 @@
             } else {
                 // Not running: rebuild full view with run buttons
                 el.innerHTML = buildSyncHTML(d, true);
-                if (window.htmx) htmx.process(el);
+                if (window.htmx) {
+                    htmx.process(el);
+                    // Nudge dashboard summary + downloads panels to refetch
+                    // immediately rather than waiting for the next 12s tick.
+                    // Other pages with hx-trigger="sync:done from:body"
+                    // partials pick this up too.
+                    htmx.trigger(document.body, 'sync:done');
+                }
             }
         }
 
@@ -1101,6 +1113,43 @@
         document.body.addEventListener('dest-deleted', destChanged);
 
         window.AudplexusDestModal = { open: open, close: close };
+    })();
+    </script>
+
+    <script>
+    // Mobile nav drawer: hamburger button toggles a body class; the
+    // backdrop + any [data-nav-dismiss] element closes. Nav links
+    // close on click so an in-app navigation doesn't leave the drawer
+    // hanging open under the new page.
+    (function(){
+        var toggleBtn = document.querySelector('[data-nav-toggle]');
+        var sidebar   = document.getElementById('primary-nav');
+        if (!toggleBtn || !sidebar) return;
+
+        function open()  {
+            document.body.classList.add('sidebar-open');
+            toggleBtn.setAttribute('aria-expanded', 'true');
+        }
+        function close() {
+            document.body.classList.remove('sidebar-open');
+            toggleBtn.setAttribute('aria-expanded', 'false');
+        }
+        function toggle() {
+            if (document.body.classList.contains('sidebar-open')) close();
+            else open();
+        }
+
+        toggleBtn.addEventListener('click', toggle);
+        document.addEventListener('click', function(e){
+            if (e.target.closest('[data-nav-dismiss]')) close();
+        });
+        // Close when a nav link is followed.
+        sidebar.querySelectorAll('a').forEach(function(a){
+            a.addEventListener('click', close);
+        });
+        document.addEventListener('keydown', function(e){
+            if (e.key === 'Escape') close();
+        });
     })();
     </script>
 </body>

--- a/internal/web/templates/book_detail_panel.html
+++ b/internal/web/templates/book_detail_panel.html
@@ -152,12 +152,74 @@
         <p class="muted" style="margin-top:1rem;font-size:.85rem">Unable to list files from disk right now.</p>
         {{end}}
 
+        {{with .BookFileInfo}}
+        <h3 class="section-label">File info</h3>
+        <dl class="meta-grid book-file-info-grid">
+            {{if .Format}}<dt>Format</dt><dd>{{.Format}}{{if .Extension}} <span class="muted">(.{{.Extension}})</span>{{end}}</dd>{{end}}
+            {{if .Codec}}<dt>Codec</dt><dd>{{if .CodecLong}}{{.CodecLong}} <span class="muted">({{.Codec}})</span>{{else}}{{.Codec}}{{end}}</dd>{{end}}
+            {{if .BitRate}}<dt>Bitrate</dt><dd>{{.BitRate}}</dd>{{end}}
+            {{if .SampleRate}}<dt>Sample rate</dt><dd>{{.SampleRate}}</dd>{{end}}
+            {{if .Channels}}<dt>Channels</dt><dd>{{.Channels}}</dd>{{end}}
+            {{if .Duration}}<dt>Duration</dt><dd>{{.Duration}}</dd>{{end}}
+            {{if gt .ChapterCount 0}}<dt>Chapters</dt><dd>{{.ChapterCount}}</dd>{{end}}
+            <dt>Embedded artwork</dt><dd>{{if .HasArtwork}}Yes{{else}}No{{end}}</dd>
+            {{if .SizeLabel}}<dt>File size</dt><dd>{{.SizeLabel}} <span class="muted">({{.SizeBytes}} bytes)</span></dd>{{end}}
+            {{if .ModifiedAt}}<dt>Modified</dt><dd>{{.ModifiedAt}}</dd>{{end}}
+            {{if .ActivationBytes}}<dt>Activation bytes</dt><dd class="cell-mono">{{.ActivationBytes}}</dd>{{end}}
+            <dt>Path</dt><dd class="cell-mono book-file-info-path">{{.Path}}</dd>
+        </dl>
+        {{if .ProbeError}}
+        <p class="muted" style="margin-top:.4rem;font-size:.78rem">Probe error: {{.ProbeError}}</p>
+        {{end}}
+        {{if .Tags}}
+        <details class="book-file-tags-details">
+            <summary>Container tags ({{len .Tags}})</summary>
+            <dl class="meta-grid book-file-tags-grid">
+                {{range .Tags}}
+                <dt class="cell-mono">{{.Key}}</dt>
+                <dd class="cell-mono book-file-tag-value">{{.Value}}</dd>
+                {{end}}
+            </dl>
+        </details>
+        {{end}}
+        {{end}}
+
         {{if .Book.Description}}
-        <div class="desc">
-            <h3 class="section-label">Description</h3>
-            <div class="book-description-html">{{safeHTML .Book.Description}}</div>
+        <h3 class="section-label">Description</h3>
+        <div class="book-description" data-collapsible>
+            <div class="book-description-html book-description-clamp">{{safeHTML .Book.Description}}</div>
+            <button type="button" class="book-description-toggle" data-collapsed-label="Show more" data-expanded-label="Show less" aria-expanded="false">Show more</button>
         </div>
         {{end}}
     </div>
 </div>
+<script>
+// Description collapse: clamp via .book-description-clamp; the toggle
+// flips the class + button label. Hides itself when the clamped
+// content fits without clipping so short descriptions don't get a
+// dangling "Show more" affordance.
+(function(){
+    var roots = document.querySelectorAll('.book-description[data-collapsible]');
+    roots.forEach(function(root){
+        var content = root.querySelector('.book-description-html');
+        var toggle  = root.querySelector('.book-description-toggle');
+        if (!content || !toggle) return;
+        // Hide the toggle when nothing is being clipped — read after a
+        // microtask so layout has settled.
+        requestAnimationFrame(function(){
+            if (content.scrollHeight <= content.clientHeight + 2) {
+                toggle.style.display = 'none';
+                content.classList.remove('book-description-clamp');
+            }
+        });
+        toggle.addEventListener('click', function(){
+            var expanded = content.classList.toggle('book-description-clamp') === false;
+            toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            toggle.textContent = expanded
+                ? toggle.dataset.expandedLabel
+                : toggle.dataset.collapsedLabel;
+        });
+    });
+})();
+</script>
 {{end}}

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -24,7 +24,7 @@
 
     <span id="sync-status" class="sync-status-wrap" hx-get="/api/sync/status" hx-trigger="load" hx-swap="innerHTML"></span>
 
-    <div id="dashboard-summary" hx-get="/api/dashboard/summary" hx-trigger="load, every 12s queue:last" hx-swap="innerHTML">
+    <div id="dashboard-summary" hx-get="/api/dashboard/summary" hx-trigger="load, every 12s queue:last, sync:done from:body" hx-swap="innerHTML">
         {{template "dashboard_summary.html" .}}
     </div>
 
@@ -37,7 +37,7 @@
         <div id="pipeline-pools" class="pool-grid pool-grid-stacked"></div>
     </div>
 
-    <div id="dashboard-downloads" hx-get="/api/dashboard/downloads" hx-trigger="load, every 12s queue:last" hx-swap="innerHTML">
+    <div id="dashboard-downloads" hx-get="/api/dashboard/downloads" hx-trigger="load, every 12s queue:last, sync:done from:body" hx-swap="innerHTML">
         {{template "dashboard_downloads.html" .}}
     </div>
 

--- a/internal/web/templates/dashboard_summary.html
+++ b/internal/web/templates/dashboard_summary.html
@@ -11,11 +11,11 @@
         <div class="value" id="stat-complete">{{.CompleteBooks}}</div>
         <div class="delta {{if gt .TotalBooks 0}}up{{end}}">{{if gt .TotalBooks 0}}{{coveragePct .CompleteBooks .TotalBooks}}% of library{{else}}—{{end}}</div>
     </div>
-    <div class="stat-card">
+    <a class="stat-card stat-card-link" href="/library?status=new">
         <div class="label">New</div>
         <div class="value" id="stat-new">{{.NewBooks}}</div>
         <div class="delta">pending action</div>
-    </div>
+    </a>
     <div class="stat-card accent">
         <div class="label">In Progress</div>
         <div class="value" id="stat-active-dl">{{.ActiveDL}}</div>

--- a/internal/web/templates/dashboard_summary.html
+++ b/internal/web/templates/dashboard_summary.html
@@ -1,31 +1,31 @@
 {{define "dashboard_summary.html"}}
 <div class="section-h">At a glance</div>
 <div class="stat-grid">
-    <div class="stat-card">
+    <a class="stat-card stat-card-link" href="/library">
         <div class="label">Library Items</div>
         <div class="value" id="stat-total">{{.TotalBooks}}</div>
         <div class="delta">total synced from Audible</div>
-    </div>
-    <div class="stat-card">
+    </a>
+    <a class="stat-card stat-card-link" href="/library?status=complete">
         <div class="label">Downloaded</div>
         <div class="value" id="stat-complete">{{.CompleteBooks}}</div>
         <div class="delta {{if gt .TotalBooks 0}}up{{end}}">{{if gt .TotalBooks 0}}{{coveragePct .CompleteBooks .TotalBooks}}% of library{{else}}—{{end}}</div>
-    </div>
+    </a>
     <a class="stat-card stat-card-link" href="/library?status=new">
         <div class="label">New</div>
         <div class="value" id="stat-new">{{.NewBooks}}</div>
         <div class="delta">pending action</div>
     </a>
-    <div class="stat-card accent">
+    <a class="stat-card accent stat-card-link" href="/library?status=downloading">
         <div class="label">In Progress</div>
         <div class="value" id="stat-active-dl">{{.ActiveDL}}</div>
         <div class="delta"><span id="stat-pending-dl">{{.PendingDL}}</span> waiting</div>
-    </div>
-    <div class="stat-card">
+    </a>
+    <a class="stat-card stat-card-link" href="/library?status=failed">
         <div class="label">Failed</div>
         <div class="value" id="stat-failed-dl">{{.FailedDL}}</div>
         <div class="delta {{if gt .FailedDL 0}}down{{else}}up{{end}}">{{if gt .FailedDL 0}}needs attention{{else}}all clear{{end}}</div>
-    </div>
+    </a>
 </div>
 
 <section aria-labelledby="dest-summary-heading">

--- a/internal/web/templates/library.html
+++ b/internal/web/templates/library.html
@@ -29,19 +29,22 @@
         <a href="/library?status=unavailable{{if $search}}&search={{$search}}{{end}}" class="{{if eq $active "unavailable"}}active{{end}}" role="tab" title="In your Audible library but not downloadable (e.g. removed from Plus)">Unavailable <span class="count">{{index .StatusCounts "unavailable"}}</span></a>
     </div>
 
+    {{$onDisk := .OnDiskFilter}}
     <div class="filter-bar">
         <div class="search-input">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
             <input type="text" name="search" placeholder="Search title, author, narrator, ASIN…"
+                   class="lib-filter"
                    hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
                    hx-trigger="keyup changed delay:300ms"
-                   hx-include="[name='status'],[name='sort'],[name='dir']"
+                   hx-include=".lib-filter"
                    value="{{$search}}">
         </div>
         <select name="status" aria-label="Filter books by status"
+                class="lib-filter"
                 hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
                 hx-trigger="change"
-                hx-include="[name='search'],[name='sort'],[name='dir']">
+                hx-include=".lib-filter">
             <option value="" {{if eq $active ""}}selected{{end}}>All statuses</option>
             <option value="new" {{if eq $active "new"}}selected{{end}}>New</option>
             <option value="queued" {{if eq $active "queued"}}selected{{end}}>Queued</option>
@@ -50,19 +53,41 @@
             <option value="failed" {{if eq $active "failed"}}selected{{end}}>Failed</option>
             <option value="unavailable" {{if eq $active "unavailable"}}selected{{end}}>Unavailable</option>
         </select>
-        <select name="sort" aria-label="Sort by"
+        <select name="on_disk" aria-label="Filter by disk presence"
+                class="lib-filter"
                 hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
                 hx-trigger="change"
-                hx-include="[name='search'],[name='status'],[name='dir']">
+                hx-include=".lib-filter">
+            <option value="" {{if eq $onDisk ""}}selected{{end}}>Any disk state</option>
+            <option value="yes" {{if eq $onDisk "yes"}}selected{{end}}>On disk</option>
+            <option value="no" {{if eq $onDisk "no"}}selected{{end}}>Not on disk</option>
+        </select>
+        {{range .PresenceFilters}}
+        <select name="presence_{{.ID}}" aria-label="Filter by presence in {{.DisplayName}}"
+                class="lib-filter"
+                hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
+                hx-trigger="change"
+                hx-include=".lib-filter">
+            <option value="" {{if eq .State ""}}selected{{end}}>Any · {{.DisplayName}}</option>
+            <option value="in" {{if eq .State "in"}}selected{{end}}>In {{.DisplayName}}</option>
+            <option value="out" {{if eq .State "out"}}selected{{end}}>Missing from {{.DisplayName}}</option>
+        </select>
+        {{end}}
+        <select name="sort" aria-label="Sort by"
+                class="lib-filter"
+                hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
+                hx-trigger="change"
+                hx-include=".lib-filter">
             <option value="purchase_date" {{if eq .Filter.SortBy "purchase_date"}}selected{{end}}>Purchased</option>
             <option value="title" {{if eq .Filter.SortBy "title"}}selected{{end}}>Title</option>
             <option value="author" {{if eq .Filter.SortBy "author"}}selected{{end}}>Author</option>
             <option value="status" {{if eq .Filter.SortBy "status"}}selected{{end}}>Status</option>
         </select>
         <select name="dir" aria-label="Sort direction"
+                class="lib-filter"
                 hx-get="/library" hx-target="#book-table" hx-swap="innerHTML"
                 hx-trigger="change"
-                hx-include="[name='search'],[name='status'],[name='sort']">
+                hx-include=".lib-filter">
             <option value="desc" {{if eq .Filter.SortDir "desc"}}selected{{end}}>Desc</option>
             <option value="asc" {{if eq .Filter.SortDir "asc"}}selected{{end}}>Asc</option>
         </select>

--- a/internal/web/templates/library_row.html
+++ b/internal/web/templates/library_row.html
@@ -9,7 +9,7 @@
             {{end}}
         </a>
     </td>
-    <td>
+    <td class="col-title">
         <div class="cell-title">
             <a href="/library/{{.Book.ID}}" class="book-detail-link" data-book-id="{{.Book.ID}}">{{.Book.Title}}</a>
             {{if eq (printf "%s" .Book.Status) "unavailable"}}
@@ -21,14 +21,14 @@
             {{if .Book.Narrator}}<small>narr. {{.Book.Narrator}}</small>{{end}}
         </div>
     </td>
-    <td>{{.Book.Author}}</td>
-    <td>
+    <td class="col-author">{{.Book.Author}}</td>
+    <td class="col-series">
         {{if .Book.Series}}<span class="cell-mono" style="color:var(--text)">{{.Book.Series}} #{{.Book.SeriesPosition}}</span>
         {{else}}<span class="cell-mono">—</span>{{end}}
     </td>
-    <td class="cell-mono">{{formatDuration .Book.Duration}}</td>
-    <td class="cell-mono">{{formatDate .Book.PurchaseDate}}</td>
-    <td><span class="badge {{statusBadge .Book.Status}}" id="status-book-{{.Book.ID}}">{{.Book.Status}}</span></td>
+    <td class="cell-mono col-duration">{{formatDuration .Book.Duration}}</td>
+    <td class="cell-mono col-purchased">{{formatDate .Book.PurchaseDate}}</td>
+    <td class="col-status"><span class="badge {{statusBadge .Book.Status}}" id="status-book-{{.Book.ID}}">{{.Book.Status}}</span></td>
     <td class="col-presence">
         {{if .Presence}}
         <div class="presence-cell" role="list" aria-label="Presence">

--- a/internal/web/templates/library_row.html
+++ b/internal/web/templates/library_row.html
@@ -55,12 +55,34 @@
     <td class="col-actions">
         <div class="table-actions" id="book-actions-{{.Book.ID}}" data-book-id="{{.Book.ID}}" data-asin="{{.Book.ASIN}}">
             <div class="library-row-default-actions{{if .BookAction.ShowCancel}} is-hidden{{end}}">
-                {{/* Primary actions, always visible. View opens the modal
-                     via the .book-detail-link delegated handler on library.html. */}}
+                {{$status := printf "%s" .Book.Status}}
+                {{/* Primary button. For books that aren't downloaded yet,
+                     Download/Retry is the headline action and View moves into
+                     the More menu. Downloaded and unavailable books keep View
+                     as the primary button. View opens the modal via the
+                     .book-detail-link delegated handler on library.html. */}}
+                {{if eq $status "new"}}
+                <button type="button" class="btn btn-small btn-primary"
+                    hx-post="/api/downloads/queue/{{.Book.ASIN}}"
+                    hx-swap="none"
+                    title="Queue download">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                    Download
+                </button>
+                {{else if eq $status "failed"}}
+                <button type="button" class="btn btn-small btn-primary"
+                    hx-post="/api/downloads/queue/{{.Book.ASIN}}"
+                    hx-swap="none"
+                    title="Retry download">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"/></svg>
+                    Retry
+                </button>
+                {{else}}
                 <a href="/library/{{.Book.ID}}" class="btn btn-small btn-secondary book-detail-link" data-book-id="{{.Book.ID}}" title="View details">
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
                     View
                 </a>
+                {{end}}
 
                 {{if .BookAction.ShowDelete}}
                 <button hx-post="/api/books/{{.Book.ID}}/delete-media?view=row"
@@ -74,32 +96,21 @@
                 </button>
                 {{end}}
 
-                {{/* "More" dropdown — Queue/Retry, Re-download, Re-sync
-                     metadata, Convert. Uses native <details> so no extra
-                     JS is needed; clicking outside closes via a
-                     library-page-level handler. */}}
+                {{/* "More" dropdown — View (when Download is primary),
+                     Re-download, Re-sync metadata, Convert. Uses native
+                     <details> so no extra JS is needed; clicking outside
+                     closes via a library-page-level handler. */}}
                 <details class="row-more-menu">
                     <summary class="btn btn-small btn-ghost row-more-toggle" aria-label="More actions" title="More actions">
                         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/></svg>
                     </summary>
                     <div class="row-more-panel" role="menu">
-                        {{if eq (printf "%s" .Book.Status) "new"}}
-                        <button type="button" class="row-more-item"
-                            hx-post="/api/downloads/queue/{{.Book.ASIN}}"
-                            hx-swap="none"
-                            role="menuitem">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                            Queue Download
-                        </button>
-                        {{else if eq (printf "%s" .Book.Status) "failed"}}
-                        <button type="button" class="row-more-item"
-                            hx-post="/api/downloads/queue/{{.Book.ASIN}}"
-                            hx-swap="none"
-                            role="menuitem">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"/></svg>
-                            Retry Download
-                        </button>
-                        {{else if eq (printf "%s" .Book.Status) "complete"}}
+                        {{if or (eq $status "new") (eq $status "failed")}}
+                        <a class="row-more-item book-detail-link" href="/library/{{.Book.ID}}" data-book-id="{{.Book.ID}}" role="menuitem">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                            View details
+                        </a>
+                        {{else if eq $status "complete"}}
                         <button type="button" class="row-more-item"
                             hx-post="/api/downloads/redownload/{{.Book.ASIN}}"
                             hx-confirm="Re-download '{{.Book.Title}}'? This removes the existing file first."

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -336,6 +336,7 @@
                 <dt class="muted">Config</dt>
                 <dd class="cell-mono">{{.ConfigPath}}</dd>
             </dl>
+            <p class="muted" style="font-size:.78rem;margin:.85rem 0 0">These paths come from your container's volume mounts and can't be changed here. To move them, update the mounts in your compose file and restart.</p>
         </div>
     </section>
 
@@ -633,13 +634,18 @@ function confirmRestart() {
     .settings-container { display: flex; flex-direction: column; gap: 1.25rem; }
     .settings-section { background: transparent; padding: 0; border: 0; }
 
+    /* The Library/Sync/Performance cards live inside a single <form>, which
+       is one flex child of .settings-container — so the container gap can't
+       reach the sections nested inside it. Give the form the same flex
+       column + gap so every card is spaced consistently. */
+    #settings-main-form { display: flex; flex-direction: column; gap: 1.25rem; }
+
     /* Bottom save bar shared by the Library + Sync + Performance form. */
     .settings-save-bar {
         display: flex;
         gap: 0.5rem;
         flex-wrap: wrap;
         align-items: center;
-        margin-top: 0.25rem;
     }
 
     /* Configuration form — two-column grid of .form-rows so we fit a

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -3,7 +3,7 @@
     <div class="page-header">
         <div>
             <h1>Settings</h1>
-            <div class="sub">Server configuration. Changes save inline; some apply only after restart.</div>
+            <div class="sub">Server configuration. Changes save as you make them.</div>
         </div>
     </div>
 
@@ -207,8 +207,8 @@
                 <div class="form-row">
                     <label for="sync_mode">Scheduled sync mode</label>
                     <select class="select" id="sync_mode" name="sync_mode">
-                        <option value="full" {{if eq .SyncMode "full"}}selected{{end}}>Full (Audible + filesystem + media server)</option>
-                        <option value="quick" {{if eq .SyncMode "quick"}}selected{{end}}>Quick (Audible-focused)</option>
+                        <option value="full" {{if eq .SyncMode "full"}}selected{{end}}>Full (Audible, your files, and media servers)</option>
+                        <option value="quick" {{if eq .SyncMode "quick"}}selected{{end}}>Quick (just check Audible)</option>
                     </select>
                     <div class="hint">Mode used by scheduled sync runs.</div>
                 </div>
@@ -227,8 +227,8 @@
 
                 <label class="form-row inline">
                     <span class="row-label">
-                        Auto-add new books to queue
-                        <div class="hint">Any book discovered with <code>new</code> status is automatically appended to the download queue after sync.</div>
+                        Automatically download new books
+                        <div class="hint">When a sync finds a new book, add it to the download queue right away. Turn this off if you'd rather pick what to download yourself.</div>
                     </span>
                     <span class="toggle">
                         <input type="checkbox" id="sync_auto_queue_new" name="sync_auto_queue_new" value="true" {{if .SyncAutoQueueNew}}checked{{end}}>
@@ -237,7 +237,6 @@
                     <input type="hidden" name="sync_auto_queue_new_sent" value="1">
                 </label>
             </div>
-            <p class="muted" style="font-size:.78rem;margin:.85rem 0 0">Sync schedule and auto-queue-new changes apply on next restart.</p>
         </div>
     </section>
 
@@ -251,19 +250,19 @@
                 <div class="form-row">
                     <label for="download_concurrency">Download workers</label>
                     <input class="input" type="number" id="download_concurrency" name="download_concurrency" value="{{.DownloadConcurrency}}" min="0" max="16">
-                    <div class="hint">0 = auto. Higher values can improve throughput on fast networks.</div>
+                    <div class="hint">0 lets Audplexus pick. Higher numbers can download faster on quick connections.</div>
                 </div>
 
                 <div class="form-row">
                     <label for="decrypt_concurrency">Decrypt workers</label>
                     <input class="input" type="number" id="decrypt_concurrency" name="decrypt_concurrency" value="{{.DecryptConcurrency}}" min="0" max="16">
-                    <div class="hint">0 = auto. This stage is CPU-heavy.</div>
+                    <div class="hint">0 lets Audplexus pick. This step works your CPU hard.</div>
                 </div>
 
                 <div class="form-row">
                     <label for="process_concurrency">Process workers</label>
                     <input class="input" type="number" id="process_concurrency" name="process_concurrency" value="{{.ProcessConcurrency}}" min="0" max="16">
-                    <div class="hint">0 = auto. Controls metadata/organize stage parallelism.</div>
+                    <div class="hint">0 lets Audplexus pick. Sets how many books get tagged and filed at once.</div>
                 </div>
 
                 <div class="form-row">
@@ -278,14 +277,14 @@
                     <div class="hint">Minimum severity for log output. Changes take effect immediately.</div>
                 </div>
             </div>
-            <p class="muted" style="font-size:.78rem;margin:.85rem 0 0">Worker concurrency changes apply on next restart.</p>
+            <p class="muted" style="font-size:.78rem;margin:.85rem 0 0">Worker count changes apply after a restart.</p>
         </div>
     </section>
 
     {{/* Single save row for the Library + Sync + Performance form. */}}
     <div class="settings-save-bar">
         <button type="submit" class="btn btn-primary">Save settings</button>
-        <button type="button" class="btn btn-secondary" hx-post="/api/library/reorganize" hx-target="#save-status" hx-swap="innerHTML">Reorganize library to current scheme</button>
+        <button type="button" class="btn btn-secondary" hx-post="/api/library/reorganize" hx-target="#save-status" hx-swap="innerHTML">Reorganize library to current settings</button>
         <span id="save-status" class="status-msg"></span>
     </div>
     </form>
@@ -306,10 +305,10 @@
                         {{end}}
                     </select>
                     <div class="hint" id="tag_profile_help">
-                        Atoms written into each m4b on download.
-                        <strong>Basic</strong> matches Audplexus's historical behavior.
-                        <strong>Audiobook-rich</strong> adds <code>series</code>, <code>series-part</code>, and <code>asin</code> — read by Audiobookshelf for series auto-grouping.
-                        Applies to subsequent downloads only.
+                        Tags saved inside each file when it downloads.
+                        <strong>Audiobook-rich</strong> (default) adds <code>series</code>, <code>series-part</code>, and <code>asin</code> tags so apps like Audiobookshelf can group series for you.
+                        <strong>Basic</strong> leaves those out and matches how older versions tagged files.
+                        Only changes files you download from now on.
                     </div>
                 </div>
                 <button type="submit" class="btn btn-secondary">Save Tag Profile</button>

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -615,7 +615,8 @@ function confirmRestart() {
 
     var focusSection = '{{.FocusSection}}';
     if (focusSection) {
-        var focusEl = document.getElementById(focusSection + '-settings');
+        var focusMap = { auth: 'section-audible' };
+        var focusEl = document.getElementById(focusMap[focusSection] || ('section-' + focusSection));
         if (focusEl) {
             focusEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
@@ -681,8 +682,11 @@ function confirmRestart() {
 </style>
 
 <script>
-// Settings TOC scroll-spy — highlights the left-rail link whose section
-// is closest to the top of the viewport. Pure JS, no deps.
+// Settings TOC scroll-spy — highlights the left-rail link for the
+// section currently under the topbar. Position-based (not an
+// IntersectionObserver) so every section is evaluated on each scroll,
+// which avoids the highlight snapping back to the top section when only
+// a subset of sections change visibility. Pure JS, no deps.
 (function() {
     var links = Array.prototype.slice.call(document.querySelectorAll('.settings-nav-link[data-section]'));
     if (!links.length) return;
@@ -691,6 +695,13 @@ function confirmRestart() {
         .filter(Boolean);
     if (!sections.length) return;
 
+    // Matches the sticky topbar offset used by the click handler below.
+    var OFFSET = 80;
+    // While a click-driven smooth scroll is animating, suppress the spy
+    // so it doesn't fight the click and revert the highlight.
+    var clickLock = false;
+    var clickTimer = null;
+
     function setActive(id) {
         links.forEach(function(a) {
             if (a.getAttribute('data-section') === id) a.classList.add('active');
@@ -698,18 +709,33 @@ function confirmRestart() {
         });
     }
 
-    var obs = new IntersectionObserver(function(entries) {
-        // Pick the visible section nearest the top.
-        var visible = entries
-            .filter(function(e) { return e.isIntersecting; })
-            .sort(function(a, b) { return a.boundingClientRect.top - b.boundingClientRect.top; });
-        if (visible[0]) setActive(visible[0].target.id);
-    }, { rootMargin: '-100px 0px -55% 0px', threshold: [0, 0.1, 0.5] });
-    sections.forEach(function(s) { obs.observe(s); });
+    function currentSection() {
+        var doc = document.documentElement;
+        // At (or near) the bottom of the page the last section can't reach
+        // the top, so anchor to it explicitly.
+        if (window.innerHeight + window.scrollY >= doc.scrollHeight - 2) {
+            return sections[sections.length - 1].id;
+        }
+        var line = window.scrollY + OFFSET;
+        var active = sections[0].id;
+        for (var i = 0; i < sections.length; i++) {
+            var top = sections[i].getBoundingClientRect().top + window.scrollY;
+            if (top <= line + 1) active = sections[i].id;
+            else break;
+        }
+        return active;
+    }
 
-    // Smooth-scroll on link click (browsers do this for #anchor, but we
-    // also want to set active immediately so the highlight doesn't lag
-    // the scroll animation).
+    function onScroll() {
+        if (clickLock) return;
+        setActive(currentSection());
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+
+    // Smooth-scroll on link click. Set active immediately and lock the spy
+    // until the scroll settles so the highlight doesn't lag or revert.
     links.forEach(function(a) {
         a.addEventListener('click', function(ev) {
             var id = a.getAttribute('data-section');
@@ -717,11 +743,19 @@ function confirmRestart() {
             if (!el) return;
             ev.preventDefault();
             setActive(id);
+            clickLock = true;
             var y = el.getBoundingClientRect().top + window.scrollY - 72;
             window.scrollTo({ top: y, behavior: 'smooth' });
             history.replaceState(null, '', '#' + id);
+            if (clickTimer) clearTimeout(clickTimer);
+            clickTimer = setTimeout(function() {
+                clickLock = false;
+                setActive(currentSection());
+            }, 700);
         });
     });
+
+    setActive(currentSection());
 })();
 </script>
 

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -749,7 +749,7 @@ function confirmRestart() {
             ev.preventDefault();
             setActive(id);
             clickLock = true;
-            var y = el.getBoundingClientRect().top + window.scrollY - 72;
+            var y = el.getBoundingClientRect().top + window.scrollY - OFFSET;
             window.scrollTo({ top: y, behavior: 'smooth' });
             history.replaceState(null, '', '#' + id);
             if (clickTimer) clearTimeout(clickTimer);

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -99,24 +99,6 @@
             {{end}}
 
             {{if eq .CurrentStep 2}}
-                <h2>Storage</h2>
-                <p class="sub">Audplexus writes processed audiobooks to the path mounted into the container. Your media servers should be able to read this same path.</p>
-                <div class="form-row">
-                    <label>Library root</label>
-                    <div class="code">{{.AudiobooksPath}}</div>
-                    <div class="hint">Configured at container startup. If this isn't right, mount a different volume to <code>/audiobooks</code> in your compose file.</div>
-                </div>
-                <div class="form-row">
-                    <label>Downloads cache</label>
-                    <div class="code">{{.DownloadsPath}}</div>
-                    <div class="hint">Temporary working directory for in-flight downloads. Doesn't need to be visible to media servers.</div>
-                </div>
-                <div class="alert">
-                    <div>Naming templates and tagging options are configurable later from <b>Settings</b>.</div>
-                </div>
-            {{end}}
-
-            {{if eq .CurrentStep 3}}
                 <h2>Add a destination</h2>
                 <p class="sub">Connect at least one media server so Audplexus knows where to push processed files. You can add more later.</p>
 
@@ -152,7 +134,7 @@
                 </div>
             {{end}}
 
-            {{if eq .CurrentStep 4}}
+            {{if eq .CurrentStep 3}}
                 <h2>You're all set.</h2>
                 <p class="sub">Audplexus is ready to run its first sync. You can change anything from Settings later.</p>
                 <div class="card">

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -166,6 +166,17 @@
                         </dd>
                     </dl>
                 </div>
+                <div class="form-row inline" style="margin-top:1rem;display:flex;align-items:center;gap:.75rem;justify-content:space-between">
+                    <span class="row-label">
+                        Automatically download new books
+                        <div class="hint" style="margin:0">When a sync finds a new book, add it to the download queue right away. You can change this later in Settings.</div>
+                    </span>
+                    <span class="toggle">
+                        <input type="checkbox" name="auto_queue_new" value="true" form="setup-finish-form" checked>
+                        <span class="toggle-slider"></span>
+                    </span>
+                </div>
+
                 {{if .Authenticated}}
                 <div class="alert ok" style="margin-top:1rem"><span class="ico">✓</span><div><b>First sync will start automatically.</b> Expect 1–3 minutes for a typical library.</div></div>
                 {{else}}
@@ -188,7 +199,7 @@
                     {{end}}
                     <a href="/setup?step={{add .CurrentStep 1}}" class="btn btn-primary">Continue →</a>
                 {{else}}
-                    <form method="POST" action="/setup/finish" style="margin:0">
+                    <form method="POST" action="/setup/finish" id="setup-finish-form" style="margin:0">
                         <button type="submit" class="btn btn-primary">Start sync</button>
                     </form>
                 {{end}}

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -148,16 +148,16 @@
                         </dd>
                     </dl>
                 </div>
-                <div class="form-row inline" style="margin-top:1rem;display:flex;align-items:center;gap:.75rem;justify-content:space-between">
+                <label class="form-row inline" for="auto_queue_new" style="margin-top:1rem;display:flex;align-items:center;gap:.75rem;justify-content:space-between">
                     <span class="row-label">
                         Automatically download new books
                         <div class="hint" style="margin:0">When a sync finds a new book, add it to the download queue right away. You can change this later in Settings.</div>
                     </span>
                     <span class="toggle">
-                        <input type="checkbox" name="auto_queue_new" value="true" form="setup-finish-form" checked>
+                        <input type="checkbox" id="auto_queue_new" name="auto_queue_new" value="true" form="setup-finish-form" checked>
                         <span class="toggle-slider"></span>
                     </span>
-                </div>
+                </label>
 
                 {{if .Authenticated}}
                 <div class="alert ok" style="margin-top:1rem"><span class="ico">✓</span><div><b>First sync will start automatically.</b> Expect 1–3 minutes for a typical library.</div></div>


### PR DESCRIPTION
**Theme:** UI Pass 2 — settings cleanup, dashboard clickability, richer book detail, smarter library filters/search, and a handful of sync/data correctness fixes.

**Settings & Wizard**
- Tidied settings spacing, dropped read-only Storage wizard step (ccb1122)
- Plainer settings wording (9caf1e3)
- Sync settings now apply without restart (1e0d5be)
- Setup wizard asks about auto-downloading new books (c019a26)
- Fixed settings section links jumping to top (6aeda0e)

**Dashboard & Navigation**
- All dashboard summary cards now clickable (0a2ad84)
- Dashboard auto-refresh, clickable New card, mobile nav + table fixes (162b01e)
- Diagnostics book links now open the book (8b2958a)

**Library & Book Detail**
- "Download" leads on rows that aren't downloaded (4249c6e)
- New libraries tag audiobooks with series info by default (4101184)
- File info block + collapsible description on book detail (5d4220e)
- Library presence filters (disk + per-destination) (4be08d1)
- Search by series and ASIN in addition to title/author (078f8d8)

**Sync & Data**
- New Metadata Repair sync phase re-tags books missing ASIN (0ffa189)
- Library total now used as destination coverage denominator (ca3fad3)
- Fixed column order in live-appended completed/failed download rows (0c91856)
