### PR TITLE
fix(library): avoid false fuzzy audiobook matches

### DIFF
--- a/internal/library/library_reconcile.go
+++ b/internal/library/library_reconcile.go
@@ -389,6 +389,7 @@ func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredF
 		return "", 0, false
 	}
 	authorKey := normalizeReconToken(book.Author)
+	seriesKey := normalizeReconToken(book.Series)
 
 	type candidate struct {
 		path  string
@@ -419,12 +420,16 @@ func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredF
 				continue
 			}
 
-			score := fuzzyReconScore(titleKey, authorKey, name, dir, whole)
+			if !fuzzyTitleMatchHasSupport(titleKey, authorKey, seriesKey, parentDir, whole) {
+				continue
+			}
+
+			score := fuzzyReconScore(titleKey, authorKey, seriesKey, name, dir, whole, parentDir)
 			matches = append(matches, candidate{path: parentDir, size: stats.totalSize, score: score})
 			continue
 		}
 
-		name := normalizeReconToken(filepath.Base(path))
+		name := normalizeReconToken(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))
 		dir := normalizeReconToken(filepath.Base(parentDir))
 		directoryPath := normalizeReconToken(parentDir)
 		whole := normalizeReconToken(path)
@@ -436,6 +441,16 @@ func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredF
 		}
 
 		authorMatchesPath := authorKey != "" && strings.Contains(whole, authorKey)
+		seriesMatchesPath := len(seriesKey) >= 4 && strings.Contains(whole, seriesKey)
+
+		// A proper-substring title match is too weak on its own. For example,
+		// Audible's "Crucible" must not match "Leadville Crucible", and
+		// "Guardian" must not match "The Guardian Guild". Accept a partial
+		// title only when the path also corroborates the Audible author or
+		// series. An exact title path component remains sufficient by itself.
+		if !pathHasExactReconComponent(path, titleKey) && !authorMatchesPath && !seriesMatchesPath {
+			continue
+		}
 
 		// Even below the directory-classification threshold, do not let an
 		// explicit chapter track create a title-only match inside a multi-file
@@ -444,11 +459,12 @@ func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredF
 			isExplicitChapterFilename(filepath.Base(path)) &&
 			nameMatchesTitle &&
 			!directoryMatchesTitle &&
-			!authorMatchesPath {
+			!authorMatchesPath &&
+			!seriesMatchesPath {
 			continue
 		}
 
-		score := fuzzyReconScore(titleKey, authorKey, name, dir, whole)
+		score := fuzzyReconScore(titleKey, authorKey, seriesKey, name, dir, whole, path)
 		matches = append(matches, candidate{path: path, size: size, score: score})
 	}
 
@@ -474,15 +490,56 @@ func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredF
 	return "", 0, false
 }
 
-func fuzzyReconScore(titleKey, authorKey, name, dir, whole string) int {
-	score := 1
-	if authorKey != "" && (strings.Contains(name, authorKey) || strings.Contains(dir, authorKey) || strings.Contains(whole, authorKey)) {
-		score += 2
+func fuzzyTitleMatchHasSupport(titleKey, authorKey, seriesKey, path, whole string) bool {
+	if pathHasExactReconComponent(path, titleKey) {
+		return true
 	}
-	if strings.Contains(name, titleKey) {
+	if authorKey != "" && strings.Contains(whole, authorKey) {
+		return true
+	}
+	return len(seriesKey) >= 4 && strings.Contains(whole, seriesKey)
+}
+
+func fuzzyReconScore(titleKey, authorKey, seriesKey, name, dir, whole, path string) int {
+	score := 1
+	if pathHasExactReconComponent(path, titleKey) {
+		score += 4
+	} else if strings.Contains(name, titleKey) || strings.Contains(dir, titleKey) {
 		score++
 	}
+	if authorKey != "" && strings.Contains(whole, authorKey) {
+		score += 3
+	}
+	if len(seriesKey) >= 4 && strings.Contains(whole, seriesKey) {
+		score += 2
+	}
 	return score
+}
+
+func pathHasExactReconComponent(path, token string) bool {
+	if token == "" {
+		return false
+	}
+
+	cleanPath := filepath.Clean(path)
+	for {
+		base := filepath.Base(cleanPath)
+		component := base
+		if isAudioFile(base) {
+			component = strings.TrimSuffix(base, filepath.Ext(base))
+		}
+		if normalizeReconToken(component) == token {
+			return true
+		}
+
+		parent := filepath.Dir(cleanPath)
+		if parent == cleanPath {
+			break
+		}
+		cleanPath = parent
+	}
+
+	return false
 }
 
 func buildDirectoryAudioStats(discoveredFiles map[string]int64) map[string]directoryAudioStats {

--- a/internal/library/library_reconcile.go
+++ b/internal/library/library_reconcile.go
@@ -150,6 +150,10 @@ func reconcileExistingAudiobookFilesWithProgress(ctx context.Context, db databas
 		Int("index_ms", int(indexMs)).
 		Msg("fs_scan: ASIN index built")
 
+	// Chapter-directory classification depends only on the discovered files, so
+	// calculate it once rather than rebuilding it for every book's fuzzy match.
+	directoryStats := buildDirectoryAudioStats(discoveredFiles)
+
 	// Phase 2: Load all books from the database
 	dbLoadStart := time.Now()
 	books, _, err := db.ListBooks(ctx, database.BookFilter{})
@@ -198,7 +202,7 @@ func reconcileExistingAudiobookFilesWithProgress(ctx context.Context, db databas
 		}
 
 		matchStart := time.Now()
-		matchedFile, matchedSize, matchMethod := findBestFileForBook(ctx, &books[i], libraryRoot, discoveredFiles, asinFileIndex)
+		matchedFile, matchedSize, matchMethod := findBestFileForBookWithDirectoryStats(ctx, &books[i], libraryRoot, discoveredFiles, asinFileIndex, directoryStats)
 		matchMs := time.Since(matchStart).Milliseconds()
 		matchTimeMs += matchMs
 
@@ -301,6 +305,10 @@ func reconcileExistingAudiobookFilesWithProgress(ctx context.Context, db databas
 //   - "candidate_path" a generated candidate path (author/title/filename layout) exists on disk
 //   - "no_match"       no file found
 func findBestFileForBook(ctx context.Context, book *database.Book, libraryRoot string, discoveredFiles map[string]int64, asinFileIndex map[string]string) (string, int64, string) {
+	return findBestFileForBookWithDirectoryStats(ctx, book, libraryRoot, discoveredFiles, asinFileIndex, buildDirectoryAudioStats(discoveredFiles))
+}
+
+func findBestFileForBookWithDirectoryStats(ctx context.Context, book *database.Book, libraryRoot string, discoveredFiles map[string]int64, asinFileIndex map[string]string, directoryStats map[string]directoryAudioStats) (string, int64, string) {
 	if book == nil {
 		return "", 0, "no_match"
 	}
@@ -344,14 +352,35 @@ func findBestFileForBook(ctx context.Context, book *database.Book, libraryRoot s
 	// Fourth choice: fuzzy title/author search across discovered paths.
 	// This helps preserve matches when users switch naming templates and older
 	// files no longer follow the generated candidate layout.
-	if path, size, ok := fuzzyMatchDiscoveredFile(book, discoveredFiles); ok {
+	if path, size, ok := fuzzyMatchDiscoveredFileWithDirectoryStats(book, discoveredFiles, directoryStats); ok {
 		return path, size, "fuzzy_title_author"
 	}
 
 	return "", 0, "no_match"
 }
 
+const (
+	chapterDirectoryMinFiles = 3
+	chapterDirectoryPercent  = 70
+)
+
+// explicitChapterFilenameRe recognizes chapter-track names such as
+// "031 - Chapter 30 - Armageddon.m4a". It deliberately requires a chapter
+// number so standalone titles such as "The Final Chapter.m4b" are not treated
+// as chapter tracks.
+var explicitChapterFilenameRe = regexp.MustCompile(`(?i)(?:^|[-_.\s])(?:chapter|chap)\s*(?:\d+|[ivxlcdm]+)\b`)
+
+type directoryAudioStats struct {
+	totalSize        int64
+	fileCount        int
+	chapterFileCount int
+}
+
 func fuzzyMatchDiscoveredFile(book *database.Book, discoveredFiles map[string]int64) (string, int64, bool) {
+	return fuzzyMatchDiscoveredFileWithDirectoryStats(book, discoveredFiles, buildDirectoryAudioStats(discoveredFiles))
+}
+
+func fuzzyMatchDiscoveredFileWithDirectoryStats(book *database.Book, discoveredFiles map[string]int64, directoryStats map[string]directoryAudioStats) (string, int64, bool) {
 	if book == nil {
 		return "", 0, false
 	}
@@ -367,24 +396,59 @@ func fuzzyMatchDiscoveredFile(book *database.Book, discoveredFiles map[string]in
 		score int
 	}
 	matches := make([]candidate, 0, 4)
-	for path, size := range discoveredFiles {
-		name := normalizeReconToken(filepath.Base(path))
-		dir := normalizeReconToken(filepath.Base(filepath.Dir(path)))
-		whole := normalizeReconToken(path)
+	chapterDirectoriesChecked := make(map[string]struct{})
 
-		if !strings.Contains(name, titleKey) && !strings.Contains(dir, titleKey) && !strings.Contains(whole, titleKey) {
+	for path, size := range discoveredFiles {
+		parentDir := filepath.Clean(filepath.Dir(path))
+		stats := directoryStats[parentDir]
+
+		// A high-confidence chapter directory represents one audiobook, not a
+		// collection of independently matchable chapter titles. Match it once
+		// using the directory path and aggregate size, and never use individual
+		// chapter filenames as fuzzy title candidates.
+		if isLikelyChapterDirectory(stats) {
+			if _, checked := chapterDirectoriesChecked[parentDir]; checked {
+				continue
+			}
+			chapterDirectoriesChecked[parentDir] = struct{}{}
+
+			name := normalizeReconToken(filepath.Base(parentDir))
+			dir := normalizeReconToken(filepath.Base(filepath.Dir(parentDir)))
+			whole := normalizeReconToken(parentDir)
+			if !strings.Contains(name, titleKey) && !strings.Contains(dir, titleKey) && !strings.Contains(whole, titleKey) {
+				continue
+			}
+
+			score := fuzzyReconScore(titleKey, authorKey, name, dir, whole)
+			matches = append(matches, candidate{path: parentDir, size: stats.totalSize, score: score})
 			continue
 		}
 
-		score := 1
-		if authorKey != "" {
-			if strings.Contains(name, authorKey) || strings.Contains(dir, authorKey) || strings.Contains(whole, authorKey) {
-				score += 2
-			}
+		name := normalizeReconToken(filepath.Base(path))
+		dir := normalizeReconToken(filepath.Base(parentDir))
+		directoryPath := normalizeReconToken(parentDir)
+		whole := normalizeReconToken(path)
+		nameMatchesTitle := strings.Contains(name, titleKey)
+		directoryMatchesTitle := strings.Contains(directoryPath, titleKey)
+
+		if !nameMatchesTitle && !strings.Contains(dir, titleKey) && !strings.Contains(whole, titleKey) {
+			continue
 		}
-		if strings.Contains(name, titleKey) {
-			score++
+
+		authorMatchesPath := authorKey != "" && strings.Contains(whole, authorKey)
+
+		// Even below the directory-classification threshold, do not let an
+		// explicit chapter track create a title-only match inside a multi-file
+		// directory belonging to an unrelated author/book.
+		if stats.fileCount > 1 &&
+			isExplicitChapterFilename(filepath.Base(path)) &&
+			nameMatchesTitle &&
+			!directoryMatchesTitle &&
+			!authorMatchesPath {
+			continue
 		}
+
+		score := fuzzyReconScore(titleKey, authorKey, name, dir, whole)
 		matches = append(matches, candidate{path: path, size: size, score: score})
 	}
 
@@ -408,6 +472,42 @@ func fuzzyMatchDiscoveredFile(book *database.Book, discoveredFiles map[string]in
 	}
 
 	return "", 0, false
+}
+
+func fuzzyReconScore(titleKey, authorKey, name, dir, whole string) int {
+	score := 1
+	if authorKey != "" && (strings.Contains(name, authorKey) || strings.Contains(dir, authorKey) || strings.Contains(whole, authorKey)) {
+		score += 2
+	}
+	if strings.Contains(name, titleKey) {
+		score++
+	}
+	return score
+}
+
+func buildDirectoryAudioStats(discoveredFiles map[string]int64) map[string]directoryAudioStats {
+	statsByDirectory := make(map[string]directoryAudioStats)
+	for path, size := range discoveredFiles {
+		dir := filepath.Clean(filepath.Dir(path))
+		stats := statsByDirectory[dir]
+		stats.totalSize += size
+		stats.fileCount++
+		if isExplicitChapterFilename(filepath.Base(path)) {
+			stats.chapterFileCount++
+		}
+		statsByDirectory[dir] = stats
+	}
+	return statsByDirectory
+}
+
+func isLikelyChapterDirectory(stats directoryAudioStats) bool {
+	return stats.fileCount >= chapterDirectoryMinFiles &&
+		stats.chapterFileCount*100 >= stats.fileCount*chapterDirectoryPercent
+}
+
+func isExplicitChapterFilename(filename string) bool {
+	nameWithoutExtension := strings.TrimSuffix(filename, filepath.Ext(filename))
+	return explicitChapterFilenameRe.MatchString(nameWithoutExtension)
 }
 
 func normalizeReconToken(s string) string {

--- a/internal/library/library_reconcile_fuzzy_regression_test.go
+++ b/internal/library/library_reconcile_fuzzy_regression_test.go
@@ -1,0 +1,85 @@
+package library
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/mstrhakr/audplexus/internal/database"
+)
+
+func TestFuzzyMatchRejectsPartialDirectoryTitleWithoutAuthorOrSeries(t *testing.T) {
+	tests := []struct {
+		name       string
+		book       database.Book
+		bookDir    string
+		chapterOne string
+	}{
+		{
+			name: "Crucible does not match Leadville Crucible",
+			book: database.Book{
+				Title:  "Crucible",
+				Author: "Travis Bagwell",
+				Series: "Awaken Online",
+			},
+			bookDir:    filepath.Join("root", "Aaron Crash", "American Dragons", "American Dragons 07 - Leadville Crucible"),
+			chapterOne: "001 - Chapter 01 - Arrival.m4a",
+		},
+		{
+			name: "Guardian does not match The Guardian Guild",
+			book: database.Book{
+				Title:  "Guardian",
+				Author: "Jack Campbell",
+				Series: "Lost Fleet Beyond the Frontier",
+			},
+			bookDir:    filepath.Join("root", "Jonathan Brooks", "Station Cores", "Station Cores 3 - The Guardian Guild"),
+			chapterOne: "001 - Chapter 01 - Guild Hall.m4a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discovered := map[string]int64{
+				filepath.Join(tt.bookDir, tt.chapterOne):                    10,
+				filepath.Join(tt.bookDir, "002 - Chapter 02 - Trouble.m4a"): 20,
+				filepath.Join(tt.bookDir, "003 - Chapter 03 - Return.m4a"):  30,
+			}
+
+			path, size, ok := fuzzyMatchDiscoveredFile(&tt.book, discovered)
+			if ok || path != "" || size != 0 {
+				t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want no match", path, size, ok)
+			}
+		})
+	}
+}
+
+func TestFuzzyMatchRejectsPartialStandaloneTitleWithoutAuthorOrSeries(t *testing.T) {
+	root := filepath.Join("root", "Aaron Crash", "American Dragons")
+	wrongFile := filepath.Join(root, "American Dragons 07 - Leadville Crucible.m4b")
+	discovered := map[string]int64{wrongFile: 100}
+	book := &database.Book{
+		Title:  "Crucible",
+		Author: "Travis Bagwell",
+		Series: "Awaken Online",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if ok || path != "" || size != 0 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want no match", path, size, ok)
+	}
+}
+
+func TestFuzzyMatchAcceptsPartialTitleWhenSeriesCorroborates(t *testing.T) {
+	root := filepath.Join("root", "Flat Library")
+	crucible := filepath.Join(root, "Awaken Online 08 - Crucible.m4b")
+	discovered := map[string]int64{crucible: 100}
+	book := &database.Book{
+		Title:  "Crucible",
+		Author: "Travis Bagwell",
+		Series: "Awaken Online",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if !ok || path != crucible || size != 100 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want (%q, %d, true)", path, size, ok, crucible, 100)
+	}
+}

--- a/internal/library/library_reconcile_test.go
+++ b/internal/library/library_reconcile_test.go
@@ -327,6 +327,139 @@ func TestFindBestFileForBookPromotesStoredChapterFileToDirectory(t *testing.T) {
 	}
 }
 
+func TestFuzzyMatchRejectsTitleFoundOnlyInChapterTrack(t *testing.T) {
+	root := filepath.Join("root")
+	bookDir := filepath.Join(root, "Dennis E. Taylor", "Bobiverse", "Bobiverse 3 - All These Worlds")
+	discovered := map[string]int64{
+		filepath.Join(bookDir, "001 - Intro.m4a"):                        10,
+		filepath.Join(bookDir, "002 - Chapter 01 - Face-Off.m4a"):        20,
+		filepath.Join(bookDir, "003 - Chapter 02 - We've Lost.m4a"):      30,
+		filepath.Join(bookDir, "004 - Chapter 03 - Trouble Brewing.m4a"): 40,
+		filepath.Join(bookDir, "005 - Chapter 04 - Attitude.m4a"):        50,
+		filepath.Join(bookDir, "006 - Chapter 05 - Bushwacked.m4a"):      60,
+		filepath.Join(bookDir, "031 - Chapter 30 - Armageddon.m4a"):      70,
+		filepath.Join(bookDir, "078 - Outro.m4a"):                        80,
+	}
+	book := &database.Book{
+		Title:  "Armageddon",
+		Author: "Travis Bagwell",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if ok || path != "" || size != 0 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want no match", path, size, ok)
+	}
+}
+
+func TestFuzzyMatchTreatsChapterDirectoryAsSingleBookCandidate(t *testing.T) {
+	root := filepath.Join("root")
+	bookDir := filepath.Join(root, "Dennis E. Taylor", "Bobiverse", "Bobiverse 3 - All These Worlds")
+	discovered := map[string]int64{
+		filepath.Join(bookDir, "001 - Intro.m4a"):                        10,
+		filepath.Join(bookDir, "002 - Chapter 01 - Face-Off.m4a"):        20,
+		filepath.Join(bookDir, "003 - Chapter 02 - We've Lost.m4a"):      30,
+		filepath.Join(bookDir, "004 - Chapter 03 - Trouble Brewing.m4a"): 40,
+		filepath.Join(bookDir, "005 - Chapter 04 - Attitude.m4a"):        50,
+		filepath.Join(bookDir, "006 - Chapter 05 - Bushwacked.m4a"):      60,
+		filepath.Join(bookDir, "031 - Chapter 30 - Armageddon.m4a"):      70,
+		filepath.Join(bookDir, "078 - Outro.m4a"):                        80,
+	}
+	book := &database.Book{
+		Title:  "All These Worlds",
+		Author: "Dennis E. Taylor",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if !ok {
+		t.Fatal("fuzzyMatchDiscoveredFile() did not match chapter directory")
+	}
+	if path != bookDir {
+		t.Fatalf("fuzzyMatchDiscoveredFile() path = %q, want %q", path, bookDir)
+	}
+	if size != 360 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() size = %d, want %d", size, 360)
+	}
+}
+
+func TestFuzzyMatchKeepsStandaloneBooksInSharedDirectory(t *testing.T) {
+	root := filepath.Join("root", "Flat Library")
+	armageddon := filepath.Join(root, "Armageddon.m4b")
+	discovered := map[string]int64{
+		armageddon: 100,
+		filepath.Join(root, "All These Worlds.m4b"):  200,
+		filepath.Join(root, "Project Hail Mary.m4b"): 300,
+	}
+	book := &database.Book{
+		Title:  "Armageddon",
+		Author: "Travis Bagwell",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if !ok {
+		t.Fatal("fuzzyMatchDiscoveredFile() did not match standalone shared-directory book")
+	}
+	if path != armageddon || size != 100 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d), want (%q, %d)", path, size, armageddon, 100)
+	}
+}
+
+func TestExplicitChapterFilenameRequiresChapterNumber(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     bool
+	}{
+		{"031 - Chapter 30 - Armageddon.m4a", true},
+		{"Chapter IV - The Return.mp3", true},
+		{"Chap 07 - Arrival.m4a", true},
+		{"The Final Chapter.m4b", false},
+		{"Chapterhouse Dune.m4b", false},
+		{"My Chapter in History.m4b", false},
+	}
+
+	for _, tt := range tests {
+		if got := isExplicitChapterFilename(tt.filename); got != tt.want {
+			t.Errorf("isExplicitChapterFilename(%q) = %v, want %v", tt.filename, got, tt.want)
+		}
+	}
+}
+
+func TestFuzzyMatchRejectsChapterCollisionBelowDirectoryThreshold(t *testing.T) {
+	root := filepath.Join("root")
+	bookDir := filepath.Join(root, "Unrelated Author", "Mixed Tracks")
+	discovered := map[string]int64{
+		filepath.Join(bookDir, "001 - Intro.m4a"):                   10,
+		filepath.Join(bookDir, "002 - Chapter 01 - Beginning.m4a"):  20,
+		filepath.Join(bookDir, "003 - Interlude.m4a"):               30,
+		filepath.Join(bookDir, "004 - Chapter 30 - Armageddon.m4a"): 40,
+		filepath.Join(bookDir, "005 - Outro.m4a"):                   50,
+	}
+	book := &database.Book{
+		Title:  "Armageddon",
+		Author: "Travis Bagwell",
+	}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if ok || path != "" || size != 0 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want no match", path, size, ok)
+	}
+}
+
+func TestFuzzyMatchDoesNotClassifyStandaloneFinalChapterAsTrack(t *testing.T) {
+	root := filepath.Join("root", "Flat Library")
+	finalChapter := filepath.Join(root, "The Final Chapter.m4b")
+	discovered := map[string]int64{
+		finalChapter:                                100,
+		filepath.Join(root, "Another Book.m4b"):     200,
+		filepath.Join(root, "Third Standalone.m4b"): 300,
+	}
+	book := &database.Book{Title: "The Final Chapter"}
+
+	path, size, ok := fuzzyMatchDiscoveredFile(book, discovered)
+	if !ok || path != finalChapter || size != 100 {
+		t.Fatalf("fuzzyMatchDiscoveredFile() = (%q, %d, %v), want (%q, %d, true)", path, size, ok, finalChapter, 100)
+	}
+}
+
 func TestReconcileExistingAudiobookFilesIgnoresUnmatchedFiles(t *testing.T) {
 	tmp := t.TempDir()
 


### PR DESCRIPTION
## Summary

Make filesystem reconciliation more conservative when fuzzy-matching existing
audiobooks, particularly split chapter folders and short Audible titles that are
substrings of unrelated local book titles.

Observed false matches included:

```text
Audible: Armageddon — Awaken Online, Book 6
Local:   Dennis E. Taylor/Bobiverse/Bobiverse 3 - All These Worlds/
         031 - Chapter 30 - Armageddon.m4a

Audible: Crucible — Awaken Online, Book 8
Local:   Aaron Crash/American Dragons/
         American Dragons 07 - Leadville Crucible

Audible: Guardian — Lost Fleet: Beyond the Frontier, Book 3
Local:   Jonathan Brooks/Station Cores/
         Station Cores 3 - The Guardian Guild
```

The existing fuzzy fallback accepted a unique normalized-title substring even
when the local author, series, and actual book title were unrelated.

## Changes

- Classify a directory as a split audiobook when it contains at least three audio
  files and at least 70% use an explicit numbered `Chapter`/`Chap` filename.
- For those directories, create one fuzzy candidate using the directory path and
  aggregate size; individual chapter filenames are not title candidates.
- Require corroboration for a proper-substring fuzzy title match:
  - an exact normalized title path component, or
  - the Audible author in the path, or
  - the Audible series in the path.
- Continue accepting exact standalone filenames such as `Crucible.m4b` without
  requiring author or series metadata.
- Continue accepting legacy names such as `Awaken Online 08 - Crucible.m4b`
  because the series corroborates the partial title match.
- Add a secondary safeguard below the 70% threshold so an explicit chapter track
  cannot create a title-only match inside an unrelated multi-file directory.
- Require a chapter number in the detector so standalone titles such as
  `The Final Chapter.m4b` are not treated as chapter tracks.
- Preserve flat directories containing multiple standalone `.m4b` books.
- Precompute directory statistics once per filesystem scan.

Stored-path, ASIN-path, and generated candidate-path matching priorities are
unchanged; this only affects the fuzzy fallback.

## Compatibility rationale

The matcher remains permissive for high-confidence layouts:

- `Crucible.m4b` matches by exact title component.
- `Travis Bagwell/Leadville Crucible.m4b` can match when the author corroborates.
- `Awaken Online 08 - Crucible.m4b` can match when the series corroborates.
- `American Dragons 07 - Leadville Crucible` does not match the unrelated
  Audible title `Crucible` when neither author nor series agrees.

For ambiguous partial-title-only paths, a false negative is preferable to
marking the wrong local audiobook complete.

## Tests

Added regression coverage for:

- rejecting the Bobiverse `Chapter 30 - Armageddon` collision;
- matching a correctly named split audiobook directory as one candidate;
- continuing to match standalone `.m4b` books kept together in a flat directory;
- recognizing numbered Arabic and Roman-numeral chapter tracks;
- not classifying `The Final Chapter`, `Chapterhouse Dune`, or similar standalone
  titles as chapter tracks;
- applying the chapter-title collision safeguard below the directory threshold;
- rejecting `Crucible` → `Leadville Crucible` with unrelated author/series;
- rejecting `Guardian` → `The Guardian Guild` with unrelated author/series; and
- accepting a partial title when the Audible series corroborates the path.